### PR TITLE
Specifies how to map the user identifier entered by the user to that passed through to LDAP

### DIFF
--- a/alpine/src/main/java/alpine/Config.java
+++ b/alpine/src/main/java/alpine/Config.java
@@ -102,6 +102,7 @@ public class Config {
         LDAP_SECURITY_AUTH       ("alpine.ldap.security.auth",        null),
         LDAP_BIND_USERNAME       ("alpine.ldap.bind.username",        null),
         LDAP_BIND_PASSWORD       ("alpine.ldap.bind.password",        null),
+		LDAP_AUTH_USERNAME_FMT   ("alpine.ldap.auth.username.format",  null),
         LDAP_ATTRIBUTE_NAME      ("alpine.ldap.attribute.name",       "userPrincipalName"),
         LDAP_ATTRIBUTE_MAIL      ("alpine.ldap.attribute.mail",       "mail"),
         HTTP_PROXY_ADDRESS       ("alpine.http.proxy.address",        null),


### PR DESCRIPTION
Added an optional LDAP configuration improvement needed for some type of servers.

Specifies how to map the username identifier entered by the user to that passed through to LDAP.
If is configured to a non-empty value, the substring %s in this value will be replaced with the entered username.
The recommended format of this value depends on your LDAP server(Active Directory, OpenLDAP, etc.).
 Examples:
   alpine.ldap.auth.username.format=%s
   alpine.ldap.auth.username.format=%s@example.com
   alpine.ldap.auth.username.format=uid=%s,ou=People,dc=example,dc=com
   alpine.ldap.auth.username.format=userPrincipalName=%s,ou=People,dc=example,dc=com
