### PR TITLE
It fails to get groups for a ldap user if CN has special characters

### DIFF
--- a/alpine/src/main/java/alpine/auth/LdapConnectionWrapper.java
+++ b/alpine/src/main/java/alpine/auth/LdapConnectionWrapper.java
@@ -274,7 +274,7 @@ public class LdapConnectionWrapper {
         if (s == null) {
             return null;
         }
-        return s.replace("{USER_DN}", user.getDN());
+        return s.replace("{USER_DN}", LdapStringSanitizer.sanitize(user.getDN()));
     }
 
     /**


### PR DESCRIPTION
In the process of integrating dependency-track with MS Active Directory, I found that it fails to get groups for a ldap user if DN's CN has special characters, e.g., `CN=firstName\, familyName`

The potential fix is to escape the **user_groups_filter** after substitution. With this fix, I am able to get groups for a ldap user with special CN.