### PR TITLE
Read password property from file

### DIFF
--- a/alpine/src/main/java/alpine/Config.java
+++ b/alpine/src/main/java/alpine/Config.java
@@ -356,12 +356,12 @@ public class Config {
      * @return a String of the value of the configuration
      * @since 1.7.0
      */
-    public String getPropertyOrFile(Key key) {
+    public String getPropertyOrFile(AlpineKey key) {
     	final AlpineKey fileKey = AlpineKey.valueOf(key.toString()+"_FILE");
     	final String filePath = getProperty(fileKey);
     	final String prop = getProperty(key);
-        if (filePath != "") {
-        	if (prop != "") {
+        if (filePath != null && filePath != "") {
+        	if (prop != null && prop != String.valueOf(key.getDefaultValue())) {
         		LOGGER.warn(fileKey.getPropertyName() + " hides property " + key.getPropertyName());
         	}
         	try {

--- a/alpine/src/main/java/alpine/auth/LdapConnectionWrapper.java
+++ b/alpine/src/main/java/alpine/auth/LdapConnectionWrapper.java
@@ -51,7 +51,7 @@ public class LdapConnectionWrapper {
     private static final Logger LOGGER = Logger.getLogger(LdapConnectionWrapper.class);
 
     private static final String BIND_USERNAME = Config.getInstance().getProperty(Config.AlpineKey.LDAP_BIND_USERNAME);
-    private static final String BIND_PASSWORD = Config.getInstance().getProperty(Config.AlpineKey.LDAP_BIND_PASSWORD);
+    private static final String BIND_PASSWORD = Config.getInstance().getPropertyOrFile(Config.AlpineKey.LDAP_BIND_PASSWORD);
     private static final String LDAP_SECURITY_AUTH = Config.getInstance().getProperty(Config.AlpineKey.LDAP_SECURITY_AUTH);
     private static final String LDAP_AUTH_USERNAME_FMT = Config.getInstance().getProperty(Config.AlpineKey.LDAP_AUTH_USERNAME_FMT);
     private static final String USER_GROUPS_FILTER = Config.getInstance().getProperty(Config.AlpineKey.LDAP_USER_GROUPS_FILTER);

--- a/alpine/src/main/java/alpine/persistence/JdoProperties.java
+++ b/alpine/src/main/java/alpine/persistence/JdoProperties.java
@@ -35,7 +35,7 @@ public final class JdoProperties {
         properties.put("javax.jdo.option.ConnectionURL", Config.getInstance().getProperty(Config.AlpineKey.DATABASE_URL));
         properties.put("javax.jdo.option.ConnectionDriverName", Config.getInstance().getProperty(Config.AlpineKey.DATABASE_DRIVER));
         properties.put("javax.jdo.option.ConnectionUserName", Config.getInstance().getProperty(Config.AlpineKey.DATABASE_USERNAME));
-        properties.put("javax.jdo.option.ConnectionPassword", Config.getInstance().getProperty(Config.AlpineKey.DATABASE_PASSWORD));
+        properties.put("javax.jdo.option.ConnectionPassword", Config.getInstance().getPropertyOrFile(Config.AlpineKey.DATABASE_PASSWORD));
         if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.DATABASE_POOL_ENABLED)) {
             properties.put("datanucleus.connectionPoolingType", "HikariCP");
             properties.put("datanucleus.connectionPool.maxPoolSize", Config.getInstance().getProperty(Config.AlpineKey.DATABASE_POOL_MAX_SIZE));

--- a/example/src/main/resources/application.properties
+++ b/example/src/main/resources/application.properties
@@ -63,6 +63,11 @@ alpine.database.driver=org.h2.Driver
 # alpine.database.password=
 
 # Optional
+# Specifies the file that contains the password to use when authenticating to the database. 
+# If password and password_file are both defined, password_file takes precedence. 
+# alpine.database.password_file=
+
+# Optional
 # Specifies if the database connection pool is enabled.
 alpine.database.pool.enabled=true
 
@@ -136,6 +141,12 @@ alpine.ldap.bind.username=
 # If anonymous access is not permitted, specify a password for the username
 # used to bind.
 alpine.ldap.bind.password=
+
+# Optional
+# If anonymous access is not permitted, specify a file that contains the password for 
+# the username used to bind.
+# If password and password_file are both defined, password_file takes precedence. 
+# alpine.ldap.bind.password_file=
 
 # Optional
 # Specifies if the username entered during login needs to be formatted prior
@@ -222,10 +233,12 @@ alpine.ldap.team.synchronization=false
 
 # Optional
 # HTTP proxy. If the address is set, then the port must be set too.
+# password_file precedes password if both are defined.
 # alpine.http.proxy.address=proxy.example.com
 # alpine.http.proxy.port=8888
 # alpine.http.proxy.username=
 # alpine.http.proxy.password=
+# alpine.http.proxy.password_file=
 
 # Optional
 # Cross-Origin Resource Sharing (CORS) headers to include in REST responses.


### PR DESCRIPTION
I propose a simple update to read password from files. I need this to be able to read password from files  created with docker secrets. If you accept this a similar change would be needed in the DT repo as well, to handle HTTP_PROXY_PASSWORD_FILE.