### PR TITLE
Allow @ characters in HTTP_URI regex sequence

### DIFF
--- a/alpine/src/main/java/alpine/validation/RegexSequence.java
+++ b/alpine/src/main/java/alpine/validation/RegexSequence.java
@@ -50,7 +50,7 @@ public class RegexSequence {
         public static final String HTTP_CONTEXT_PATH = "^\\/?[a-zA-Z0-9.\\-\\/_]*$";
         public static final String HTTP_PATH = "^[a-zA-Z0-9.\\-_]*$";
         public static final String HTTP_QUERY_STRING = "^[\\w()\\-=\\*\\.\\?;,+\\/:& %]*$";
-        public static final String HTTP_URI = "^[\\w()\\-=\\*\\.\\?;,+\\/:& ]*$";
+        public static final String HTTP_URI = "^[\\w()\\-=\\*\\.\\?;,+\\/:&@ ]*$";
         public static final String HTTP_URL = "^.*$";
         public static final String HTTP_JSESSION_ID = "^[A-Z0-9]{10,128}$";
 


### PR DESCRIPTION
Required to match URI that contain authentication information (http://user@example.com) or in the case of packageurl the version (pkg:maven/us.springett/alpine@1.8.0-SNAPSHOT).