### PR TITLE
Use a more generic approach for parsing OIDC UserInfo responses

### DIFF
--- a/alpine/src/main/java/alpine/auth/OidcAuthenticationService.java
+++ b/alpine/src/main/java/alpine/auth/OidcAuthenticationService.java
@@ -68,6 +68,7 @@ public class OidcAuthenticationService implements AuthenticationService {
         final String username = userInfo.getClaim(usernameClaim, String.class);
         if (username == null) {
             LOGGER.error("The configured OIDC username claim (" + usernameClaim + ") could not be found in UserInfo response");
+            LOGGER.debug("Claims returned in UserInfo response: " + userInfo.getClaims());
             throw new AlpineAuthenticationException(AlpineAuthenticationException.CauseType.OTHER);
         }
 

--- a/alpine/src/main/java/alpine/auth/OidcUserInfo.java
+++ b/alpine/src/main/java/alpine/auth/OidcUserInfo.java
@@ -1,6 +1,5 @@
 package alpine.auth;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 
 import java.util.HashMap;
@@ -26,11 +25,10 @@ public class OidcUserInfo {
         return getClaim("email", String.class);
     }
 
-    @JsonAnyGetter
     public Map<String, Object> getClaims() {
         return claims;
     }
-    
+
     @SuppressWarnings("unchecked")
     public <T> T getClaim(final String key, final Class<T> clazz) {
         final Object claim = claims.get(key);

--- a/alpine/src/main/java/alpine/auth/OidcUserInfo.java
+++ b/alpine/src/main/java/alpine/auth/OidcUserInfo.java
@@ -2,7 +2,6 @@ package alpine.auth;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -13,35 +12,25 @@ import java.util.Map;
  */
 public class OidcUserInfo {
 
-    @JsonProperty("sub")
-    private String subject;
+    private final Map<String, Object> claims;
 
-    @JsonProperty("email")
-    private String email;
-
-    private Map<String, Object> claims = new HashMap<>();
-
-    public String getSubject() {
-        return subject;
+    OidcUserInfo() {
+        claims = new HashMap<>();
     }
 
-    public void setSubject(final String subject) {
-        this.subject = subject;
+    public String getSubject() {
+        return getClaim("sub", String.class);
     }
 
     public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(final String email) {
-        this.email = email;
+        return getClaim("email", String.class);
     }
 
     @JsonAnyGetter
     public Map<String, Object> getClaims() {
         return claims;
     }
-
+    
     @SuppressWarnings("unchecked")
     public <T> T getClaim(final String key, final Class<T> clazz) {
         final Object claim = claims.get(key);

--- a/alpine/src/test/java/alpine/auth/OidcUserInfoTest.java
+++ b/alpine/src/test/java/alpine/auth/OidcUserInfoTest.java
@@ -20,14 +20,16 @@ public class OidcUserInfoTest {
                 "    \"sub\": \"666\",\n" +
                 "    \"name\": \"user\",\n" +
                 "    \"nickname\": \"user666\",\n" +
-                "    \"email\": \"user@mail.local\",\n" +
+                "    \"email\": \"user@example.com\",\n" +
                 "    \"email_verified\": true,\n" +
                 "    \"groups\": [\"groupName1\",\"groupName2\"]\n" +
                 "}";
 
         final OidcUserInfo userInfo = new ObjectMapper().readValue(userInfoJson, OidcUserInfo.class);
         assertThat(userInfo.getSubject()).isEqualTo("666");
-        assertThat(userInfo.getEmail()).isEqualTo("user@mail.local");
+        assertThat(userInfo.getEmail()).isEqualTo("user@example.com");
+        assertThat(userInfo.getClaim("sub", String.class)).isEqualTo("666");
+        assertThat(userInfo.getClaim("email", String.class)).isEqualTo("user@example.com");
         assertThat(userInfo.getClaim("nickname", String.class)).isEqualTo("user666");
         assertThat(userInfo.getClaim("email_verified", Boolean.class)).isTrue();
         assertThat(userInfo.getClaim("groups", List.class)).containsExactly("groupName1", "groupName2");


### PR DESCRIPTION
Fixes an issue where users couldn't use "email" as username claim, see https://owasp.slack.com/archives/C6R3R32H4/p1616153299039200

The configured claim [would be accessed via `OidcUserInfo#getClaim`](https://github.com/stevespringett/Alpine/blob/alpine-parent-1.9.1/alpine/src/main/java/alpine/auth/OidcAuthenticationService.java#L68), which in turn was populated with `@JsonAnySetter`. Because `email` was already annotated with `@JsonProperty`, it wouldn't be passed to the any setter and thus wasn't accessible via `#getClaim`, see https://fasterxml.github.io/jackson-annotations/javadoc/2.9/com/fasterxml/jackson/annotation/JsonAnySetter.html. 