### PR TITLE
fix: fixed security issue which cause leakage of API keys to logs

### DIFF
--- a/alpine/src/main/java/alpine/model/ApiKey.java
+++ b/alpine/src/main/java/alpine/model/ApiKey.java
@@ -92,7 +92,9 @@ public class ApiKey implements Serializable, Principal {
     @Deprecated
     @JsonIgnore
     public String getName() {
-        return getKey();
+        String key = getKey();
+
+        return key.substring(0, 4) + "****" + key.substring(key.length() - 4);
     }
 
     public List<Team> getTeams() {

--- a/alpine/src/test/java/alpine/model/ApiKeyTest.java
+++ b/alpine/src/test/java/alpine/model/ApiKeyTest.java
@@ -36,8 +36,8 @@ public class ApiKeyTest {
     public void keyTest() {
         ApiKey key = new ApiKey();
         key.setKey("12345");
-        Assert.assertEquals("12345", key.getKey());
-        Assert.assertEquals("12345", key.getName());
+        Assert.assertEquals("12345678901234567890", key.getKey());
+        Assert.assertEquals("1234****7890", key.getName());
     }
 
     @Test


### PR DESCRIPTION
Now for example in Dependency Track logs I see:

```
15:57:17.662 INFO [ProjectResource] Project pkg:npm/internal-app/domains-advanced-dns-application@deploy-production updated by z3KFI9e5d[EDITED]ChhF2
15:57:18.362 INFO [BomUploadProcessingTask] Processing CycloneDX BOM uploaded to project: 086f785e-4478-4ac9-886d-349d7281a71b
15:57:18.420 INFO [ProjectResource] Project pkg:npm/internal-app/domains-advanced-dns-application@deploy-production updated by z3KFI9e5d[EDITED]ChhF2
15:57:19.078 INFO [ProjectResource] Project pkg:npm/%40nodejsTools/eslint-config@3.4.1 updated by z3KFI9e5d[EDITED]ChhF2
```