### PR TITLE
add USERNAME template in LDAP wrapper

### DIFF
--- a/alpine/src/main/java/alpine/auth/LdapConnectionWrapper.java
+++ b/alpine/src/main/java/alpine/auth/LdapConnectionWrapper.java
@@ -341,7 +341,7 @@ public class LdapConnectionWrapper {
         if (s == null) {
             return null;
         }
-        return s.replace("{USER_DN}", LdapStringSanitizer.sanitize(user.getDN()));
+        return s.replace("{USER_DN}", LdapStringSanitizer.sanitize(user.getDN())).replace("{USERNAME}", LdapStringSanitizer.sanitize(user.getUsername()));
     }
 
     private String searchTermSubstitution(final String ldapFilter, String searchTerm) {

--- a/example/src/main/resources/application.properties
+++ b/example/src/main/resources/application.properties
@@ -202,13 +202,16 @@ alpine.ldap.users.search.filter=(&(objectClass=user)(objectCategory=Person)(cn=*
 # Optional
 # Specifies the LDAP search filter to use to query a user and retrieve a list
 # of groups the user is a member of. The {USER_DN} variable will be substituted
-# with the actual value of the users DN at runtime.
+# with the actual value of the users DN at runtime. The {USERNAME} variable will
+# be substituted with the actual value of the user's username at runtime. 
 # Example (Microsoft Active Directory):
 #    alpine.ldap.user.groups.filter=(&(objectClass=group)(objectCategory=Group)(member={USER_DN}))
 # Example (Microsoft Active Directory - with nested group support):
 #    alpine.ldap.user.groups.filter=(member:1.2.840.113556.1.4.1941:={USER_DN})
 # Example (ApacheDS, Fedora 389 Directory, NetIQ/Novell eDirectory, etc):
 #    alpine.ldap.user.groups.filter=(&(objectClass=groupOfUniqueNames)(uniqueMember={USER_DN}))
+# Example (OpenLDAP):
+#    alpine.ldap.user.groups.filter=(&(objectClass=posixGroup)(memberUid={USERNAME}))
 alpine.ldap.user.groups.filter=(member:1.2.840.113556.1.4.1941:={USER_DN})
 
 # Optional


### PR DESCRIPTION
In our company, we use Dependency-Track which connects to our internal OpenLDAP. The problem is, that Dependency-Track doesn’t synchronise groups with teams. After triple-checking our configuration, I discovered that the filter for synchronising groups uses `memberUid={USER_DN}`. In our LDAP, however, `memberUid`s in groups are `uid`s, which are the same as usernames. It turns out that the only template that will be substituted in this filter is `{USER_DN}`.

W specifically need a template for usernames so I didn’t think adding a column for `uid` is wise, given that one for username already exists. That’s why I didn’t change `LdapUser`.