### PR TITLE
Update DataNucleus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,15 +163,13 @@
         <lib.commons.collections4.version>4.4</lib.commons.collections4.version>
         <lib.commons.io.version>2.11.0</lib.commons.io.version>
         <lib.commons.lang3.version>3.12.0</lib.commons.lang3.version>
-        <lib.datanucleus-api-jdo.version>5.2.7</lib.datanucleus-api-jdo.version>
+        <lib.datanucleus-api-jdo.version>5.2.9</lib.datanucleus-api-jdo.version>
         <!-- Auto-generated classes have warnings which break build
              https://github.com/datanucleus/datanucleus-jdo-query/pull/10
         <lib.datanucleus-jdo-query.version>5.0.6</lib.datanucleus-jdo-query.version>
         -->
-        <!-- DO NOT UPDATE Datanucleus RDBMS beyond 5.2.7 (for now) due to breaking changes introduced in
-             https://github.com/datanucleus/datanucleus-rdbms/pull/375
-        -->
-        <lib.datanucleus.version>5.2.7</lib.datanucleus.version>
+        <lib.datanucleus.version>5.2.10</lib.datanucleus.version>
+        <lib.datanucleus-rdbms.version>5.2.11</lib.datanucleus-rdbms.version>
         <lib.h2.version>1.4.200</lib.h2.version>
         <lib.hikaricp.version>4.0.3</lib.hikaricp.version>
         <lib.javassist.version>3.28.0-GA</lib.javassist.version>
@@ -333,7 +331,7 @@
             <dependency>
                 <groupId>org.datanucleus</groupId>
                 <artifactId>datanucleus-rdbms</artifactId>
-                <version>${lib.datanucleus.version}</version>
+                <version>${lib.datanucleus-rdbms.version}</version>
             </dependency>
             <!--
             <dependency>


### PR DESCRIPTION
Bump all DN components to their newest version.

An issue with PostgreSQL in DN >= 5.2.8 that prevented us from updating has been resolved in `datanucleus-rdbms` 5.2.11 (https://github.com/datanucleus/datanucleus-rdbms/issues/437)

Signed-off-by: nscuro <nscuro@protonmail.com>

---

Tested with PostgreSQL 14.2