### PR TITLE
Make message body mime type configurable

### DIFF
--- a/alpine-server/src/main/java/alpine/server/mail/SendMail.java
+++ b/alpine-server/src/main/java/alpine/server/mail/SendMail.java
@@ -49,6 +49,7 @@ public class SendMail {
     private Address[] bcc;
     private String subject;
     private String body;
+    private String bodyMimeType;
     private File[] attachments = {};
     private String host;
     private int port;
@@ -102,6 +103,11 @@ public class SendMail {
 
     public SendMail body(final String body) {
         this.body = body;
+        return this;
+    }
+
+    public SendMail bodyMimeType(final String bodyMimeType) {
+        this.bodyMimeType = bodyMimeType;
         return this;
     }
 
@@ -224,7 +230,13 @@ public class SendMail {
 
             message.setSubject(subject);
             BodyPart messageBodyPart = new MimeBodyPart();
-            messageBodyPart.setText(body);
+
+            if(bodyMimeType != null) {
+                messageBodyPart.setContent(body, bodyMimeType);
+            } else {
+                messageBodyPart.setText(body);
+            }
+
             Multipart multipart = new MimeMultipart();
             multipart.addBodyPart(messageBodyPart);
 


### PR DESCRIPTION
Allow client code to set body mime type if needed, plain/text remains default if no mime type is set

Signed-off-by: Alioune SY <sy_alioune@yahoo.fr>

First of all, thank you for all your work.

This PR is related to DependencyTrack/dependency-track#275 and aim to propagate mail body mime type all the way to Alpine framework.

Please find related PR below :

- [Dependency Track backend PR 1760](https://github.com/DependencyTrack/dependency-track/pull/1760)
- [Dependency Track frontend PR 183](https://github.com/DependencyTrack/frontend/pull/183)