### PR TITLE
Raise baseline Java version to 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,11 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3.0.2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
-        java-version: 11
+        distribution: 'temurin'
+        java-version: "17"
     - name: Install tools
       run: |
         sudo apt-get install jq

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+target/

--- a/alpine-common/src/main/java/alpine/common/util/ByteFormat.java
+++ b/alpine-common/src/main/java/alpine/common/util/ByteFormat.java
@@ -19,6 +19,7 @@
 package alpine.common.util;
 
 import java.text.NumberFormat;
+import java.util.Locale;
 
 /**
  * Class to render a byte count as a human-readable string such as "1 KB" or "1 GB" instead of a raw number
@@ -50,7 +51,7 @@ public class ByteFormat {
      * @since 1.0.0
      */
     public ByteFormat() {
-        numberFormat = NumberFormat.getIntegerInstance();
+        numberFormat = NumberFormat.getIntegerInstance(Locale.ENGLISH);
         names = new String[]{" GB", " MB", " KB", " byte"};
         numberFormat.setMinimumFractionDigits(0);
         numberFormat.setMaximumFractionDigits(1);

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>
         <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
         <maven.shade.plugin.version>3.3.0</maven.shade.plugin.version>
-        <maven.datanucleus.plugin.version>5.2.1</maven.datanucleus.plugin.version>
+        <maven.datanucleus.plugin.version>6.0.0-release</maven.datanucleus.plugin.version>
         <maven.versions.plugin.version>2.11.0</maven.versions.plugin.version>
         <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
         <maven.enforcer.plugin.version>3.0.0</maven.enforcer.plugin.version>
@@ -163,13 +163,8 @@
         <lib.commons.collections4.version>4.4</lib.commons.collections4.version>
         <lib.commons.io.version>2.11.0</lib.commons.io.version>
         <lib.commons.lang3.version>3.12.0</lib.commons.lang3.version>
-        <lib.datanucleus-api-jdo.version>5.2.9</lib.datanucleus-api-jdo.version>
-        <!-- Auto-generated classes have warnings which break build
-             https://github.com/datanucleus/datanucleus-jdo-query/pull/10
-        <lib.datanucleus-jdo-query.version>5.0.6</lib.datanucleus-jdo-query.version>
-        -->
-        <lib.datanucleus.version>5.2.10</lib.datanucleus.version>
-        <lib.datanucleus-rdbms.version>5.2.11</lib.datanucleus-rdbms.version>
+        <lib.datanucleus-api-jdo.version>6.0.0-m4</lib.datanucleus-api-jdo.version>
+        <lib.datanucleus.version>6.0.0-m4</lib.datanucleus.version>
         <lib.h2.version>1.4.200</lib.h2.version>
         <lib.hikaricp.version>4.0.3</lib.hikaricp.version>
         <lib.javassist.version>3.29.0-GA</lib.javassist.version>

--- a/pom.xml
+++ b/pom.xml
@@ -163,8 +163,9 @@
         <lib.commons.collections4.version>4.4</lib.commons.collections4.version>
         <lib.commons.io.version>2.11.0</lib.commons.io.version>
         <lib.commons.lang3.version>3.12.0</lib.commons.lang3.version>
-        <lib.datanucleus-api-jdo.version>6.0.0-m4</lib.datanucleus-api-jdo.version>
-        <lib.datanucleus.version>6.0.0-m4</lib.datanucleus.version>
+        <lib.datanucleus-api-jdo.version>6.0.0-release</lib.datanucleus-api-jdo.version>
+        <lib.datanucleus.version>6.0.0-release</lib.datanucleus.version>
+        <lib.datanucleus-rdbms.version>6.0.0-release</lib.datanucleus-rdbms.version>
         <lib.h2.version>1.4.200</lib.h2.version>
         <lib.hikaricp.version>4.0.3</lib.hikaricp.version>
         <lib.javassist.version>3.29.0-GA</lib.javassist.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
     <properties>
         <!-- Maven Build Properties -->
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <timestamp>${maven.build.timestamp}</timestamp>

--- a/pom.xml
+++ b/pom.xml
@@ -544,6 +544,11 @@
                 <version>${maven.jar.plugin.version}</version>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${maven.war.plugin.version}</version>
+            </plugin>
+            <plugin>
                 <groupId>us.springett</groupId>
                 <artifactId>maven-uuid-generator</artifactId>
                 <version>${maven.uuidgenerator.plugin.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
+                    <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
                     <reuseForks>false</reuseForks>
                     <forkCount>1</forkCount>
                 </configuration>


### PR DESCRIPTION
Surprisingly few changes necessary for this upgrade. Beside DataNucleus, all other libraries are already Java 17 compatible, including Jersey. Adoption in DT is equally unproblematic.

Closes #383