### PR TITLE
Add support for protecting metrics with basic authentication

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -130,6 +130,8 @@ public class Config {
         LDAP_USER_PROVISIONING    ("alpine.ldap.user.provisioning",     false),
         LDAP_TEAM_SYNCHRONIZATION ("alpine.ldap.team.synchronization",  false),
         METRICS_ENABLED           ("alpine.metrics.enabled",            false),
+        METRICS_AUTH_USERNAME     ("alpine.metrics.auth.username",      null),
+        METRICS_AUTH_PASSWORD     ("alpine.metrics.auth.password",      null),
         OIDC_ENABLED              ("alpine.oidc.enabled",               false),
         OIDC_ISSUER               ("alpine.oidc.issuer",                null),
         OIDC_CLIENT_ID            ("alpine.oidc.client.id",             null),

--- a/alpine-server/src/test/java/alpine/server/servlets/MetricsServletTest.java
+++ b/alpine-server/src/test/java/alpine/server/servlets/MetricsServletTest.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.server.servlets;
+
+import alpine.Config;
+import io.prometheus.client.exporter.common.TextFormat;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MetricsServletTest {
+
+    private Config configMock;
+    private HttpServletRequest requestMock;
+    private HttpServletResponse responseMock;
+    private ByteArrayOutputStream responseOutputStream;
+    private PrintWriter responseWriter;
+
+    @Before
+    public void setUp() {
+        configMock = mock(Config.class);
+        requestMock = mock(HttpServletRequest.class);
+        responseMock = mock(HttpServletResponse.class);
+        responseOutputStream = new ByteArrayOutputStream();
+        responseWriter = new PrintWriter(responseOutputStream);
+    }
+
+    @Test
+    public void shouldRespondWithMetricsWhenEnabled() throws Exception {
+        when(configMock.getPropertyAsBoolean(eq(Config.AlpineKey.METRICS_ENABLED))).thenReturn(true);
+
+        when(responseMock.getWriter()).thenReturn(responseWriter);
+
+        final var servlet = new MetricsServlet(configMock);
+        servlet.init();
+        servlet.doGet(requestMock, responseMock);
+
+        verify(responseMock).setStatus(eq(HttpServletResponse.SC_OK));
+        verify(responseMock).setHeader(eq(HttpHeaders.CONTENT_TYPE), eq(TextFormat.CONTENT_TYPE_004));
+        assertThat(responseOutputStream.toString()).isEmpty();
+    }
+
+    @Test
+    public void shouldRespondWithNotFoundWhenNotEnabled() throws Exception {
+        when(responseMock.getWriter()).thenReturn(responseWriter);
+
+        final var servlet = new MetricsServlet(configMock);
+        servlet.init();
+        servlet.doGet(requestMock, responseMock);
+
+        verify(responseMock).setStatus(eq(HttpServletResponse.SC_NOT_FOUND));
+        assertThat(responseOutputStream.toString()).isEmpty();
+    }
+
+    @Test
+    public void shouldRespondWithMetricsWhenEnabledAndAuthenticated() throws Exception {
+        when(configMock.getPropertyAsBoolean(eq(Config.AlpineKey.METRICS_ENABLED))).thenReturn(true);
+        when(configMock.getProperty(eq(Config.AlpineKey.METRICS_AUTH_USERNAME))).thenReturn("metrics-user");
+        when(configMock.getProperty(eq(Config.AlpineKey.METRICS_AUTH_PASSWORD))).thenReturn("metrics-password");
+
+        when(requestMock.getHeader(eq(HttpHeaders.AUTHORIZATION))).thenReturn("Basic bWV0cmljcy11c2VyOm1ldHJpY3MtcGFzc3dvcmQ");
+
+        when(responseMock.getWriter()).thenReturn(responseWriter);
+
+        final var servlet = new MetricsServlet(configMock);
+        servlet.init();
+        servlet.doGet(requestMock, responseMock);
+
+        verify(responseMock).setStatus(eq(HttpServletResponse.SC_OK));
+        verify(responseMock).setHeader(eq(HttpHeaders.CONTENT_TYPE), eq(TextFormat.CONTENT_TYPE_004));
+        assertThat(responseOutputStream.toString()).isEmpty();
+    }
+
+    @Test
+    public void shouldRespondWithUnauthorizedWhenEnabledAndAuthenticationFailed() throws Exception {
+        when(configMock.getPropertyAsBoolean(eq(Config.AlpineKey.METRICS_ENABLED))).thenReturn(true);
+        when(configMock.getProperty(eq(Config.AlpineKey.METRICS_AUTH_USERNAME))).thenReturn("metrics-user");
+        when(configMock.getProperty(eq(Config.AlpineKey.METRICS_AUTH_PASSWORD))).thenReturn("metrics-password");
+
+        when(requestMock.getHeader(eq(HttpHeaders.AUTHORIZATION))).thenReturn("Basic Zm9vOmJhcg");
+
+        when(responseMock.getWriter()).thenReturn(responseWriter);
+
+        final var servlet = new MetricsServlet(configMock);
+        servlet.init();
+        servlet.doGet(requestMock, responseMock);
+
+        verify(responseMock).setStatus(eq(HttpServletResponse.SC_UNAUTHORIZED));
+        assertThat(responseOutputStream.toString()).isEmpty();
+    }
+
+}


### PR DESCRIPTION
The metrics endpoint is intended to be used by machines, and access has to be available as soon as the application starts. While it's not viable to integrate this endpoint with Alpine's default AuthN/AuthZ model, basic auth is a good compromise.

Also, Prometheus supports basic auth, but not custom headers like `X-Api-Key` or similar.

Signed-off-by: nscuro <nscuro@protonmail.com>