### PR TITLE
Add support for persistence metrics

### DIFF
--- a/alpine-infra/src/main/java/alpine/persistence/JdoProperties.java
+++ b/alpine-infra/src/main/java/alpine/persistence/JdoProperties.java
@@ -53,6 +53,9 @@ public final class JdoProperties {
         properties.put(PropertyNames.PROPERTY_QUERY_JDOQL_ALLOWALL, "true");
         properties.put(PropertyNames.PROPERTY_MULTITHREADED, "true");
         properties.put("javax.jdo.option.Multithreaded", "true");
+        if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.METRICS_ENABLED)) {
+            properties.put(PropertyNames.PROPERTY_ENABLE_STATISTICS, "true");
+        }
         return properties;
     }
 

--- a/alpine-server/src/main/java/alpine/server/persistence/PersistenceManagerFactory.java
+++ b/alpine-server/src/main/java/alpine/server/persistence/PersistenceManagerFactory.java
@@ -20,12 +20,20 @@ package alpine.server.persistence;
 
 import alpine.Config;
 import alpine.common.logging.Logger;
+import alpine.common.metrics.Metrics;
 import alpine.model.InstalledUpgrades;
 import alpine.model.SchemaVersion;
 import alpine.persistence.IPersistenceManagerFactory;
 import alpine.persistence.JdoProperties;
+import com.zaxxer.hikari.HikariDataSource;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.datanucleus.PersistenceNucleusContext;
 import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+import org.datanucleus.store.connection.ConnectionManagerImpl;
+import org.datanucleus.store.rdbms.ConnectionFactoryImpl;
+import org.datanucleus.store.rdbms.RDBMSStoreManager;
 import org.datanucleus.store.schema.SchemaAwareStoreManager;
 
 import javax.jdo.JDOHelper;
@@ -45,6 +53,7 @@ import java.util.Set;
 public class PersistenceManagerFactory implements IPersistenceManagerFactory, ServletContextListener {
 
     private static final Logger LOGGER = Logger.getLogger(PersistenceManagerFactory.class);
+    private static final String METRICS_PREFIX = "alpine_persistence_";
 
     private static JDOPersistenceManagerFactory pmf;
     //private static final ThreadLocal<PersistenceManager> PER_THREAD_PM = new ThreadLocal<>();
@@ -53,6 +62,23 @@ public class PersistenceManagerFactory implements IPersistenceManagerFactory, Se
     public void contextInitialized(ServletContextEvent event) {
         LOGGER.info("Initializing persistence framework");
         pmf = (JDOPersistenceManagerFactory)JDOHelper.getPersistenceManagerFactory(JdoProperties.get(), "Alpine");
+
+        if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.METRICS_ENABLED)) {
+            LOGGER.info("Registering persistence metrics");
+            registerMetrics(pmf);
+
+            if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.DATABASE_POOL_ENABLED)) {
+                LOGGER.info("Registering connection pool metrics");
+                try {
+                    registerConnectionPoolMetrics(pmf);
+                } catch (Exception ex) {
+                    // An exception may be thrown here when accessing hidden fields
+                    // via reflection failed. Potentially because fields were renamed.
+                    // Nothing mission-critical, but users should still be warned.
+                    LOGGER.warn("An unexpected error occurred while registering connection pool metrics", ex);
+                }
+            }
+        }
 
         // Ensure that the UpgradeMetaProcessor and SchemaVersion tables are created NOW, not dynamically at runtime.
         final PersistenceNucleusContext ctx = pmf.getNucleusContext();
@@ -118,6 +144,114 @@ public class PersistenceManagerFactory implements IPersistenceManagerFactory, Se
         if (pmf != null) {
             pmf.close();
             pmf = null;
+        }
+    }
+
+    private void registerMetrics(final JDOPersistenceManagerFactory pmf) {
+        FunctionCounter.builder(METRICS_PREFIX + "datastore_reads_total", pmf,
+                        p -> p.getNucleusContext().getStatistics().getNumberOfDatastoreReads())
+                .description("Total number of read operations from the datastore")
+                .register(Metrics.getRegistry());
+
+        FunctionCounter.builder(METRICS_PREFIX + "datastore_writes_total", pmf,
+                        p -> p.getNucleusContext().getStatistics().getNumberOfDatastoreWrites())
+                .description("Total number of write operations to the datastore")
+                .register(Metrics.getRegistry());
+
+        FunctionCounter.builder(METRICS_PREFIX + "object_fetches_total", pmf,
+                        p -> p.getNucleusContext().getStatistics().getNumberOfObjectFetches())
+                .description("Total number of objects fetched from the datastore")
+                .register(Metrics.getRegistry());
+
+        FunctionCounter.builder(METRICS_PREFIX + "object_inserts_total", pmf,
+                        p -> p.getNucleusContext().getStatistics().getNumberOfObjectInserts())
+                .description("Total number of objects inserted into the datastore")
+                .register(Metrics.getRegistry());
+
+        FunctionCounter.builder(METRICS_PREFIX + "object_updates_total", pmf,
+                        p -> p.getNucleusContext().getStatistics().getNumberOfObjectUpdates())
+                .description("Total number of objects updated in the datastore")
+                .register(Metrics.getRegistry());
+
+        FunctionCounter.builder(METRICS_PREFIX + "object_deletes_total", pmf,
+                        p -> p.getNucleusContext().getStatistics().getNumberOfObjectDeletes())
+                .description("Total number of objects deleted from the datastore")
+                .register(Metrics.getRegistry());
+
+        Gauge.builder(METRICS_PREFIX + "query_execution_time_ms_avg", pmf,
+                        p -> p.getNucleusContext().getStatistics().getQueryExecutionTimeAverage())
+                .description("Average query execution time in milliseconds")
+                .register(Metrics.getRegistry());
+
+        Gauge.builder(METRICS_PREFIX + "queries_active", pmf,
+                        p -> p.getNucleusContext().getStatistics().getQueryActiveTotalCount())
+                .description("Number of currently active queries")
+                .register(Metrics.getRegistry());
+
+        FunctionCounter.builder(METRICS_PREFIX + "queries_executed_total", pmf,
+                        p -> p.getNucleusContext().getStatistics().getQueryExecutionTotalCount())
+                .description("Total number of executed queries")
+                .register(Metrics.getRegistry());
+
+        FunctionCounter.builder(METRICS_PREFIX + "queries_failed_total", pmf,
+                        p -> p.getNucleusContext().getStatistics().getQueryErrorTotalCount())
+                .description("Total number of queries that completed with an error")
+                .register(Metrics.getRegistry());
+
+        Gauge.builder(METRICS_PREFIX + "transaction_execution_time_ms_avg", pmf,
+                        p -> p.getNucleusContext().getStatistics().getTransactionExecutionTimeAverage())
+                .description("Average transaction execution time in milliseconds")
+                .register(Metrics.getRegistry());
+
+        FunctionCounter.builder(METRICS_PREFIX + "transactions_active", pmf,
+                        p -> p.getNucleusContext().getStatistics().getTransactionActiveTotalCount())
+                .description("Number of currently active transactions")
+                .register(Metrics.getRegistry());
+
+        FunctionCounter.builder(METRICS_PREFIX + "transactions_total", pmf,
+                        p -> p.getNucleusContext().getStatistics().getTransactionTotalCount())
+                .description("Total number of transactions")
+                .register(Metrics.getRegistry());
+
+        FunctionCounter.builder(METRICS_PREFIX + "transactions_committed_total", pmf,
+                        p -> p.getNucleusContext().getStatistics().getTransactionCommittedTotalCount())
+                .description("Total number of committed transactions")
+                .register(Metrics.getRegistry());
+
+        FunctionCounter.builder(METRICS_PREFIX + "transactions_rolledback_total", pmf,
+                        p -> p.getNucleusContext().getStatistics().getTransactionRolledBackTotalCount())
+                .description("Total number of rolled-back transactions")
+                .register(Metrics.getRegistry());
+
+        // This number does not necessarily equate the number of physical connections.
+        // It resembles the number of active connections MANAGED BY DATANUCLEUS.
+        // The number of connections reported by connection pool metrics will differ.
+        Gauge.builder(METRICS_PREFIX + "connections_active", pmf,
+                        p -> p.getNucleusContext().getStatistics().getConnectionActiveCurrent())
+                .description("Number of currently active managed datastore connections")
+                .register(Metrics.getRegistry());
+    }
+
+    private void registerConnectionPoolMetrics(final JDOPersistenceManagerFactory pmf) throws IllegalAccessException {
+        // HikariCP has native support for Dropwizard and Micrometer metrics.
+        // However, DataNucleus doesn't provide access to the underlying DataSource
+        // after the PMF has been created. We use reflection to still get access
+        // to it and register it with the global metrics registry.
+        // In the future, we may construct the DataSources ourselves, so that this
+        // workaround won't be necessary anymore.
+        if (pmf.getNucleusContext().getStoreManager() instanceof final RDBMSStoreManager storeManager
+                && storeManager.getConnectionManager() instanceof final ConnectionManagerImpl connectionManager) {
+            registerConnectionPoolMetricsForConnectionFactory(FieldUtils.readField(connectionManager, "primaryConnectionFactory", true));
+            registerConnectionPoolMetricsForConnectionFactory(FieldUtils.readField(connectionManager, "secondaryConnectionFactory", true));
+        }
+    }
+
+    private void registerConnectionPoolMetricsForConnectionFactory(final Object connectionFactory) throws IllegalAccessException {
+        if (connectionFactory instanceof final ConnectionFactoryImpl connectionFactoryImpl) {
+            final Object dataSource = FieldUtils.readField(connectionFactoryImpl, "dataSource", true);
+            if (dataSource instanceof final HikariDataSource hikariDataSource) {
+                hikariDataSource.setMetricRegistry(Metrics.getRegistry());
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds metrics support for both DataNucleus and HikariCP, providing insights into how the persistence layer of Alpine is doing.

While DataNucleus provides a more high-level view of things, the HikariCP metrics will hopefully allow users to better tune their pool size. 

Note: The DataNucleus statistics are not thread safe until datanucleus-core 6.0.2 (see https://github.com/datanucleus/datanucleus-core/pull/478) and may yield weird numbers as a consequence. They'll start to emit reliable numbers as soon as we update to 6.0.2.

Here's an example of how this may look in a Grafana dashboard:

![Screenshot 2022-09-10 at 14 40 55](https://user-images.githubusercontent.com/5693141/189483901-1c63840a-2037-4daf-9a94-5a8e13b39ebb.png)

