### PR TITLE
Disable `javax.jdo.option.Multithreaded`

### DIFF
--- a/alpine-infra/src/main/java/alpine/persistence/JdoProperties.java
+++ b/alpine-infra/src/main/java/alpine/persistence/JdoProperties.java
@@ -51,8 +51,6 @@ public final class JdoProperties {
         properties.put(PropertyNames.PROPERTY_SCHEMA_AUTOCREATE_CONSTRAINTS, "true");
         properties.put(PropertyNames.PROPERTY_SCHEMA_GENERATE_DATABASE_MODE, "create");
         properties.put(PropertyNames.PROPERTY_QUERY_JDOQL_ALLOWALL, "true");
-        properties.put(PropertyNames.PROPERTY_MULTITHREADED, "true");
-        properties.put("javax.jdo.option.Multithreaded", "true");
         return properties;
     }
 
@@ -70,8 +68,6 @@ public final class JdoProperties {
         properties.put(PropertyNames.PROPERTY_SCHEMA_AUTOCREATE_CONSTRAINTS, "true");
         properties.put(PropertyNames.PROPERTY_SCHEMA_GENERATE_DATABASE_MODE, "create");
         properties.put(PropertyNames.PROPERTY_QUERY_JDOQL_ALLOWALL, "true");
-        properties.put("javax.jdo.option.Multithreaded", "true");
-        properties.put(PropertyNames.PROPERTY_MULTITHREADED, "true");
         return properties;
     }
 }


### PR DESCRIPTION
PMs are not designed to be used by multiple threads, and setting `javax.jdo.option.Multithreaded` is no guarantee for thread safety.

The expectation is that applications using Alpine are aware of this. `EntityManager`s in JPA / Hibernate are not thread safe either, so this concept is nothing new.

The locking logic employed by DN when the PM is multithreaded may cause deadlocks, even if it isn't used by multiple threads, see https://github.com/datanucleus/datanucleus-core/issues/479

Signed-off-by: nscuro <nscuro@protonmail.com>