### PR TITLE
Update datanucleus-core and datanucleus-rdbms to 6.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,9 +163,9 @@
         <lib.commons.collections4.version>4.4</lib.commons.collections4.version>
         <lib.commons.io.version>2.11.0</lib.commons.io.version>
         <lib.commons.lang3.version>3.12.0</lib.commons.lang3.version>
-        <lib.datanucleus-api-jdo.version>6.0.0-release</lib.datanucleus-api-jdo.version>
-        <lib.datanucleus.version>6.0.0-release</lib.datanucleus.version>
-        <lib.datanucleus-rdbms.version>6.0.0-release</lib.datanucleus-rdbms.version>
+        <lib.datanucleus-api-jdo.version>6.0.1</lib.datanucleus-api-jdo.version>
+        <lib.datanucleus.version>6.0.2</lib.datanucleus.version>
+        <lib.datanucleus-rdbms.version>6.0.2</lib.datanucleus-rdbms.version>
         <lib.h2.version>2.1.214</lib.h2.version>
         <lib.hikaricp.version>4.0.3</lib.hikaricp.version>
         <lib.javassist.version>3.29.0-GA</lib.javassist.version>


### PR DESCRIPTION
Also update datanucleus-api-jdo to 6.0.1, there is no 6.0.2 version for it yet.

This will resolve a blocker we have for DT 4.6, caused by datanucleus-rdbms <= 6.0.1 not working with MSSQL: https://github.com/DependencyTrack/dependency-track/issues/1930