### PR TITLE
Use proxy (if provided) for OIDC configuration

### DIFF
--- a/alpine-server/src/main/java/alpine/server/auth/OidcConfigurationResolver.java
+++ b/alpine-server/src/main/java/alpine/server/auth/OidcConfigurationResolver.java
@@ -87,14 +87,7 @@ public class OidcConfigurationResolver {
             Issuer issuerObject = new Issuer(this.issuer);
             URL configURL = OIDCProviderMetadata.resolveURL(issuerObject);
             HTTPRequest httpRequest = new HTTPRequest(HTTPRequest.Method.GET, configURL);
-
-            String proxyHost = Config.getInstance().getProperty(Config.AlpineKey.HTTP_PROXY_ADDRESS);
-            String proxyPort = Config.getInstance().getProperty(Config.AlpineKey.HTTP_PROXY_PORT);
-
-            if (proxyHost != null && proxyPort != null) {
-                int proxyPortAsInt = Config.getInstance().getPropertyAsInt(Config.AlpineKey.HTTP_PROXY_PORT);
-                httpRequest.setProxy(new Proxy(Proxy.Type.HTTP,new InetSocketAddress(proxyHost,proxyPortAsInt)));
-            }
+            httpRequest.setProxy(OidcProxyHelper.getProxyForHost(configURL));
 
             HTTPResponse httpResponse = httpRequest.send();
 

--- a/alpine-server/src/main/java/alpine/server/auth/OidcConfigurationResolver.java
+++ b/alpine-server/src/main/java/alpine/server/auth/OidcConfigurationResolver.java
@@ -23,11 +23,17 @@ import alpine.Config;
 import alpine.common.logging.Logger;
 import alpine.server.cache.CacheManager;
 import com.nimbusds.oauth2.sdk.GeneralException;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import net.minidev.json.JSONObject;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.URL;
 
 /**
  * @since 1.8.0
@@ -77,23 +83,50 @@ public class OidcConfigurationResolver {
         }
 
         LOGGER.debug("Fetching OIDC configuration from issuer " + issuer);
-        final OIDCProviderMetadata providerMetadata;
         try {
-            providerMetadata = OIDCProviderMetadata.resolve(new Issuer(issuer));
+            Issuer issuerObject = new Issuer(this.issuer);
+            URL configURL = OIDCProviderMetadata.resolveURL(issuerObject);
+            HTTPRequest httpRequest = new HTTPRequest(HTTPRequest.Method.GET, configURL);
+
+            String proxyHost = Config.getInstance().getProperty(Config.AlpineKey.HTTP_PROXY_ADDRESS);
+            String proxyPort = Config.getInstance().getProperty(Config.AlpineKey.HTTP_PROXY_PORT);
+
+            if (proxyHost != null && proxyPort != null) {
+                int proxyPortAsInt = Config.getInstance().getPropertyAsInt(Config.AlpineKey.HTTP_PROXY_PORT);
+                httpRequest.setProxy(new Proxy(Proxy.Type.HTTP,new InetSocketAddress(proxyHost,proxyPortAsInt)));
+            }
+
+            HTTPResponse httpResponse = httpRequest.send();
+
+            if (httpResponse.getStatusCode() != 200) {
+                throw new IOException("Couldn't download OpenID Provider metadata from " + configURL +
+                        ": Status code " + httpResponse.getStatusCode());
+            }
+
+            JSONObject jsonObject = httpResponse.getContentAsJSONObject();
+
+            OIDCProviderMetadata op = OIDCProviderMetadata.parse(jsonObject);
+
+            if (!issuerObject.equals(op.getIssuer())) {
+                throw new GeneralException("The returned issuer doesn't match the expected: " + op.getIssuer());
+            }
+
+            configuration = new OidcConfiguration();
+            configuration.setIssuer(op.getIssuer().getValue());
+            configuration.setJwksUri(op.getJWKSetURI());
+            configuration.setUserInfoEndpointUri(op.getUserInfoEndpointURI());
+
+            LOGGER.debug("Storing OIDC configuration in cache: " + configuration);
+            CacheManager.getInstance().put(CONFIGURATION_CACHE_KEY, configuration);
+
+            return configuration;
+
         } catch (IOException | GeneralException e) {
             LOGGER.error("Failed to fetch OIDC configuration from issuer " + issuer, e);
             return null;
         }
 
-        configuration = new OidcConfiguration();
-        configuration.setIssuer(providerMetadata.getIssuer().getValue());
-        configuration.setJwksUri(providerMetadata.getJWKSetURI());
-        configuration.setUserInfoEndpointUri(providerMetadata.getUserInfoEndpointURI());
 
-        LOGGER.debug("Storing OIDC configuration in cache: " + configuration);
-        CacheManager.getInstance().put(CONFIGURATION_CACHE_KEY, configuration);
-
-        return configuration;
     }
 
 }

--- a/alpine-server/src/main/java/alpine/server/auth/OidcProxyHelper.java
+++ b/alpine-server/src/main/java/alpine/server/auth/OidcProxyHelper.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+
+package alpine.server.auth;
+
+import alpine.Config;
+
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+
+/**
+ * @since 1.8.0
+ */
+class OidcProxyHelper {
+
+    static Proxy getProxyForHost(URL configURL) throws MalformedURLException {
+        String proxyHost = Config.getInstance().getProperty(Config.AlpineKey.HTTP_PROXY_ADDRESS);
+        String proxyPort = Config.getInstance().getProperty(Config.AlpineKey.HTTP_PROXY_PORT);
+        String noProxy = Config.getInstance().getProperty(Config.AlpineKey.NO_PROXY);
+
+        if (proxyHost == null){
+            return null;
+        }
+
+        if (proxyPort == null){
+            return null;
+        }
+
+        if (isTargetHostInNoProxy(configURL, noProxy)){
+            return null;
+        }
+
+        int proxyPortAsInt = Config.getInstance().getPropertyAsInt(Config.AlpineKey.HTTP_PROXY_PORT);
+        return new Proxy(Proxy.Type.HTTP,new InetSocketAddress(proxyHost,proxyPortAsInt));
+    }
+
+    static boolean isTargetHostInNoProxy(URL url, String noProxy) throws MalformedURLException {
+        if (noProxy == null){
+            return false;
+        }
+        for (String noProxyHost : noProxy.split(",") ) {
+            if ("*".equals(noProxyHost)) {
+                return true;
+            }
+            URL noProxyURL = new URL(noProxyHost);
+            if (url.getHost().equals(noProxyURL.getHost()) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/alpine-server/src/main/java/alpine/server/auth/OidcUserInfoAuthenticator.java
+++ b/alpine-server/src/main/java/alpine/server/auth/OidcUserInfoAuthenticator.java
@@ -20,6 +20,7 @@
 package alpine.server.auth;
 
 import alpine.common.logging.Logger;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.UserInfoRequest;
 import com.nimbusds.openid.connect.sdk.UserInfoResponse;
@@ -42,10 +43,9 @@ class OidcUserInfoAuthenticator {
     OidcProfile authenticate(final String accessToken, final OidcProfileCreator profileCreator) throws AlpineAuthenticationException {
         final UserInfoResponse userInfoResponse;
         try {
-            final var httpResponse =
-                    new UserInfoRequest(configuration.getUserInfoEndpointUri(), new BearerAccessToken(accessToken))
-                            .toHTTPRequest()
-                            .send();
+            HTTPRequest httpRequest = new UserInfoRequest(configuration.getUserInfoEndpointUri(), new BearerAccessToken(accessToken)).toHTTPRequest();
+            httpRequest.setProxy(OidcProxyHelper.getProxyForHost(configuration.getUserInfoEndpointUri().toURL()));
+            final var httpResponse = httpRequest.send();
             userInfoResponse = UserInfoResponse.parse(httpResponse);
         } catch (IOException e) {
             LOGGER.error("UserInfo request failed", e);


### PR DESCRIPTION
As discussed in [Dependency Track boards](https://github.com/DependencyTrack/dependency-track/issues/1940), proxies are not supported for OIDC configuration.

As the feature involves multiple projects : 

1. [Dependency Track](https://github.com/DependencyTrack/dependency-track)
2. Alpine (this one)
3. [Oauth-sdk OIDC](https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions)

there is not one obivous place where the fix should be done.

I chose to perform everything inside this project as it is closely related to Dependency Track (where the issue is blocking).

Change summary : Instead of calling directly [oauth-sdk's resolve OIDC config](https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/a6e867c9b38e6d5e946e29fc8d478a455dce0b98/src/main/java/com/nimbusds/openid/connect/sdk/op/OIDCProviderMetadata.java#lines-1876) method, I chose to split it in two steps (that are actually performed internally by the function) : 
- Fetch the config (using basic HTTPRequest with default parameters, where I added the proxy support)
- Call [oauth-sdk's parse method](https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/a6e867c9b38e6d5e946e29fc8d478a455dce0b98/src/main/java/com/nimbusds/openid/connect/sdk/op/OIDCProviderMetadata.java#lines-1434)

Feel free to discuss, ask questions, request changes if necessary.