### PR TITLE
Save and load secret key using encoded bytes format instead of Object Serialization

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -98,6 +98,7 @@ public class Config {
         WORKER_THREADS            ("alpine.worker.threads",             0),
         WORKER_THREAD_MULTIPLIER  ("alpine.worker.thread.multiplier",   4),
         DATA_DIRECTORY            ("alpine.data.directory",             "~/.alpine"),
+        SECRET_KEY_PATH           ("alpine.secret.key.path",            null),
         DATABASE_MODE             ("alpine.database.mode",              "embedded"),
         DATABASE_PORT             ("alpine.database.port",              9092),
         DATABASE_URL              ("alpine.database.url",               "jdbc:h2:mem:alpine"),

--- a/alpine-infra/src/test/java/alpine/security/crypto/KeyManagerTest.java
+++ b/alpine-infra/src/test/java/alpine/security/crypto/KeyManagerTest.java
@@ -18,9 +18,9 @@
  */
 package alpine.security.crypto;
 
-import alpine.security.crypto.KeyManager;
 import org.junit.Assert;
 import org.junit.Test;
+
 import javax.crypto.SecretKey;
 import java.security.KeyPair;
 
@@ -45,4 +45,30 @@ public class KeyManagerTest {
         Assert.assertTrue(KeyManager.getInstance().secretKeyExists());
         Assert.assertEquals(secretKey, KeyManager.getInstance().getSecretKey());
     }
+
+    @Test
+    public void saveAndLoadSecretKeyInLegacyFormatTest() throws Exception {
+        final SecretKey secretKey = KeyManager.getInstance().generateSecretKey();
+        KeyManager.getInstance().save(secretKey);
+        final SecretKey loadedKey = KeyManager.getInstance().loadSecretKey();
+        Assert.assertArrayEquals(secretKey.getEncoded(), loadedKey.getEncoded());
+    }
+
+    @Test
+    public void saveAndLoadSecretKeyInEncodedFormatTest() throws Exception {
+        final SecretKey secretKey = KeyManager.getInstance().generateSecretKey();
+        KeyManager.getInstance().saveEncoded(secretKey);
+        final SecretKey loadedKey = KeyManager.getInstance().loadEncodedSecretKey();
+        Assert.assertArrayEquals(secretKey.getEncoded(), loadedKey.getEncoded());
+    }
+
+    @Test
+    public void secretKeyHasOldFormatTest() throws Exception {
+        final SecretKey secretKey = KeyManager.getInstance().generateSecretKey();
+        KeyManager.getInstance().save(secretKey);
+        Assert.assertTrue(KeyManager.getInstance().secretKeyHasOldFormat());
+        KeyManager.getInstance().saveEncoded(secretKey);
+        Assert.assertFalse(KeyManager.getInstance().secretKeyHasOldFormat());
+    }
+
 }

--- a/example/src/main/resources/application.properties
+++ b/example/src/main/resources/application.properties
@@ -24,6 +24,12 @@ alpine.worker.thread.multiplier=4
 # files or directories.
 alpine.data.directory=~/.alpine-example
 
+# Optional
+# Defines the path to the secret key to be used for data encryption and decryption.
+# The key will be generated upon first startup if it does not exist.
+# Default is "<alpine.data.directory>/keys/secret.key".
+# alpine.secret.key.path=/var/run/secrets/secret.key
+
 # Required
 # Defines the interval (in seconds) to log general heath information.
 # If value equals 0, watchdog logging will be disabled.


### PR DESCRIPTION
Using OS makes it impractical to provide a key that was generated before Alpine / the application using Alpine was first launched.

Secret keys can be loaded both in the old and the new format. This is done for backwards compatibility. Existing deployments of Alpine-based apps will not have to do anything and continue to function as before.

New keys will only be generated in the new encoded format. There is no automatic conversion of existing keys happening, because some users of Alpine may already have the key file set to read-only.

Additionally, the location of the secret key is now configurable. This is important to have when using k8s secrets, as nested mounts (e.g. `-v "./data:/data" -v "./secret.key:/data/.alpine/keys/secret.key"`) are an anti-pattern.

Closes #436