### PR TITLE
Fix user email attribute not being persisted and fetched from LDAP server

### DIFF
--- a/alpine-model/src/main/java/alpine/model/LdapUser.java
+++ b/alpine-model/src/main/java/alpine/model/LdapUser.java
@@ -76,9 +76,11 @@ public class LdapUser implements Serializable, Principal, UserPrincipal {
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private List<Team> teams;
 
+    @Persistent
+    @Column(name = "EMAIL", allowsNull = "true")
     @Size(max = 255)
     @Pattern(regexp = "[\\P{Cc}]+", message = "The email address must not contain control characters")
-    private transient String email; // not persisted - will be retrieved from the directory service
+    private String email;
 
     @Persistent(table = "LDAPUSERS_PERMISSIONS", defaultFetchGroup = "true")
     @Join(column = "LDAPUSER_ID")

--- a/alpine-server/src/main/java/alpine/server/auth/LdapConnectionWrapper.java
+++ b/alpine-server/src/main/java/alpine/server/auth/LdapConnectionWrapper.java
@@ -212,9 +212,7 @@ public class LdapConnectionWrapper {
     public List<String> search(final DirContext dirContext, final String filter, final String searchTerm) throws NamingException {
         LOGGER.debug("Searching / filter: " + filter + " searchTerm: " + searchTerm);
         final List<String> entityDns = new ArrayList<>();
-        final String[] attributeFilter = {};
         final SearchControls sc = new SearchControls();
-        sc.setReturningAttributes(attributeFilter);
         sc.setSearchScope(SearchControls.SUBTREE_SCOPE);
         final String searchFor = searchTermSubstitution(filter, searchTerm);
         LOGGER.debug("Searching for: " + searchFor);
@@ -239,9 +237,7 @@ public class LdapConnectionWrapper {
      */
     public List<SearchResult> searchForUsername(final DirContext ctx, final String username) throws NamingException {
         LOGGER.debug("Performing a directory search for: " + username);
-        final String[] attributeFilter = {};
         final SearchControls sc = new SearchControls();
-        sc.setReturningAttributes(attributeFilter);
         sc.setSearchScope(SearchControls.SUBTREE_SCOPE);
         final String searchFor = LdapConnectionWrapper.ATTRIBUTE_NAME + "=" +
                 LdapStringSanitizer.sanitize(formatPrincipal(username));


### PR DESCRIPTION
See https://github.com/DependencyTrack/dependency-track/issues/2320#issuecomment-1361666943 and https://github.com/DependencyTrack/dependency-track/pull/2371#issuecomment-1385649780 for reference.

Currently, no email addresses are fetched from the LDAP server for LDAP users. And even if they were correctly fetched, it would always be required to sync the email addresses from the server before using them, resulting in an unnecessary overhead.
This can be avoided by persisting the email address of a LDAP user every time it is synced from the LDAP server.

With this PR, the attributes of a LDAP user are now all fetched from the LDAP server and the fetched email attribute of the LDAP user is now being persisted for future use in other contexts.