### PR TITLE
Port proxy util methods from Dependency-Track

### DIFF
--- a/alpine-common/pom.xml
+++ b/alpine-common/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>system-rules</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/alpine-common/src/main/java/alpine/common/util/ProxyConfig.java
+++ b/alpine-common/src/main/java/alpine/common/util/ProxyConfig.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.common.util;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Set;
+
+/**
+ * HTTP proxy configuration.
+ * <p>
+ * Ported from Dependency-Track's {@code ManagedHttpClientFactory}.
+ *
+ * @see <a href="https://github.com/DependencyTrack/dependency-track/blob/4.7.0/src/main/java/org/dependencytrack/common/ManagedHttpClientFactory.java">Source</a>
+ * @since 2.3.0
+ */
+public final class ProxyConfig {
+
+    private String host;
+    private int port;
+    private String domain;
+    private String username;
+    private String password;
+    private Set<String> noProxy;
+
+    /**
+     * Determines if proxy should be used or not for a given {@link URI}.
+     * <p>
+     * Ported from Dependency-Track's {@code ManagedHttpClientFactory}.
+     *
+     * @param uri the URL that is being called by this application
+     * @return {@code true} if proxy is to be used, {@code false} if not
+     * @see <a href="https://github.com/DependencyTrack/dependency-track/blob/4.7.0/src/main/java/org/dependencytrack/common/ManagedHttpClientFactory.java">Source</a>
+     */
+    public boolean shouldProxy(final URL uri) {
+        if (host == null || uri == null || !Set.of("http", "https").contains(uri.getProtocol())) {
+            return false;
+        }
+        if (noProxy == null) {
+            return true;
+        }
+        if (noProxy.contains("*")) {
+            return false;
+        }
+
+        final String hostname = uri.getHost();
+        int hostPort = uri.getPort();
+
+        for (final String bypassURL : noProxy) {
+            final String[] bypassURLList = bypassURL.split(":");
+            final String byPassHost = bypassURLList[0];
+            int byPassPort = -1;
+            if (bypassURLList.length == 2) {
+                byPassPort = Integer.parseInt(bypassURLList[1]);
+            }
+            if (hostPort == byPassPort || byPassPort == -1) {
+                if (hostname.equalsIgnoreCase(byPassHost)) {
+                    return false;
+                }
+                int hl = hostname.length();
+                int bl = byPassHost.length();
+                if (hl > bl && hostname.substring(hl - bl - 1).equalsIgnoreCase("." + byPassHost)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(final String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(final int port) {
+        this.port = port;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(final String domain) {
+        this.domain = domain;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(final String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+
+    public Set<String> getNoProxy() {
+        return noProxy;
+    }
+
+    public void setNoProxy(final Set<String> noProxy) {
+        this.noProxy = noProxy;
+    }
+
+}

--- a/alpine-common/src/main/java/alpine/common/util/ProxyUtil.java
+++ b/alpine-common/src/main/java/alpine/common/util/ProxyUtil.java
@@ -1,0 +1,209 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.common.util;
+
+import alpine.Config;
+import alpine.common.logging.Logger;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Utility class for working with HTTP proxies.
+ *
+ * @since 2.3.0
+ */
+public final class ProxyUtil {
+
+    private static final Logger LOGGER = Logger.getLogger(ProxyUtil.class);
+
+    private ProxyUtil() {
+    }
+
+    /**
+     * Attempt to use application specific proxy settings if they exist.
+     * Otherwise, attempt to use environment variables if they exist.
+     * <p>
+     * Ported from Dependency-Track's {@code ManagedHttpClientFactory}.
+     *
+     * @return A {@link ProxyConfig} object, or {@code null} if no proxy is configured
+     * @see <a href="https://github.com/DependencyTrack/dependency-track/blob/4.7.0/src/main/java/org/dependencytrack/common/ManagedHttpClientFactory.java">Source</a>
+     */
+    @SuppressWarnings("unused")
+    public static ProxyConfig getProxyConfig() {
+        ProxyConfig proxyCfg = fromConfig(Config.getInstance());
+        if (proxyCfg == null) {
+            proxyCfg = fromEnvironment(System.getenv());
+        }
+        return proxyCfg;
+    }
+
+    /**
+     * Creates a {@link ProxyConfig} object from the application.properties configuration.
+     * <p>
+     * Ported from Dependency-Track's {@code ManagedHttpClientFactory}.
+     *
+     * @return A {@link ProxyConfig} object, or {@code null} if no proxy is configured
+     * @see <a href="https://github.com/DependencyTrack/dependency-track/blob/4.7.0/src/main/java/org/dependencytrack/common/ManagedHttpClientFactory.java">Source</a>
+     */
+    static ProxyConfig fromConfig(final Config config) {
+        if (config == null) {
+            return null;
+        }
+
+        final String host = config.getProperty(Config.AlpineKey.HTTP_PROXY_ADDRESS);
+        if (host == null) {
+            return null;
+        }
+
+        final int port = config.getPropertyAsInt(Config.AlpineKey.HTTP_PROXY_PORT);
+        final String username = config.getProperty(Config.AlpineKey.HTTP_PROXY_USERNAME);
+        final String password = config.getPropertyOrFile(Config.AlpineKey.HTTP_PROXY_PASSWORD);
+        final String noProxy = config.getProperty(Config.AlpineKey.NO_PROXY);
+
+        final var proxyCfg = new ProxyConfig();
+        proxyCfg.setHost(host);
+        if (port != -1) {
+            proxyCfg.setPort(port);
+        }
+
+        if (username != null) {
+            final Pair<String, String> domainUsername = parseProxyUsername(username);
+            Optional.ofNullable(domainUsername.getLeft()).ifPresent(proxyCfg::setDomain);
+            Optional.ofNullable(domainUsername.getRight()).ifPresent(proxyCfg::setUsername);
+        }
+        if (password != null) {
+            proxyCfg.setPassword(StringUtils.trimToNull(password));
+        }
+        if (noProxy != null) {
+            proxyCfg.setNoProxy(Set.of(noProxy.split(",")));
+        }
+
+        return proxyCfg;
+    }
+
+    /**
+     * Creates a {@link ProxyConfig} object from the environment.
+     * <p>
+     * Ported from Dependency-Track's {@code ManagedHttpClientFactory}.
+     *
+     * @return A {@link ProxyConfig} object, or {@code null} if no proxy is configured
+     * @see <a href="https://github.com/DependencyTrack/dependency-track/blob/4.7.0/src/main/java/org/dependencytrack/common/ManagedHttpClientFactory.java">Source</a>
+     */
+    static ProxyConfig fromEnvironment(final Map<String, String> env) {
+        ProxyConfig proxyCfg = null;
+        try {
+            proxyCfg = buildFromEnvironment(env, "https_proxy");
+            if (proxyCfg == null) {
+                proxyCfg = buildFromEnvironment(env, "http_proxy");
+            }
+        } catch (MalformedURLException | SecurityException | UnsupportedEncodingException e) {
+            LOGGER.warn("Could not parse proxy settings from environment", e);
+        }
+
+        if (proxyCfg != null) {
+            for (Map.Entry<String, String> entry : env.entrySet()) {
+                if ("no_proxy".equalsIgnoreCase(entry.getKey().toUpperCase())) {
+                    proxyCfg.setNoProxy(Set.of(entry.getValue().split(",")));
+                    break;
+                }
+            }
+        }
+
+        return proxyCfg;
+    }
+
+    /**
+     * Retrieves and parses the {@code https_proxy} and {@code http_proxy} settings.
+     * This method ignores the case of the variables in the environment.
+     * <p>
+     * Ported from Dependency-Track's {@code ManagedHttpClientFactory}.
+     *
+     * @param variable the name of the environment variable
+     * @return a {@link ProxyConfig} object, or {@code null} if proxy is not defined
+     * @throws MalformedURLException if the URL of the proxy setting cannot be parsed
+     * @throws SecurityException     if the environment variable cannot be retrieved
+     * @see <a href="https://github.com/DependencyTrack/dependency-track/blob/4.7.0/src/main/java/org/dependencytrack/common/ManagedHttpClientFactory.java">Source</a>
+     */
+    private static ProxyConfig buildFromEnvironment(final Map<String, String> env, final String variable)
+            throws MalformedURLException, UnsupportedEncodingException {
+        if (env == null || variable == null) {
+            return null;
+        }
+
+        String proxy = null;
+        for (Map.Entry<String, String> entry : env.entrySet()) {
+            if (variable.equalsIgnoreCase(entry.getKey().toUpperCase())) {
+                proxy = entry.getValue();
+                break;
+            }
+        }
+        if (proxy == null) {
+            return null;
+        }
+
+        final var proxyUrl = new URL(proxy);
+        final var proxyCfg = new ProxyConfig();
+        proxyCfg.setHost(proxyUrl.getHost());
+        proxyCfg.setPort(proxyUrl.getPort());
+
+        if (proxyUrl.getUserInfo() != null) {
+            final String[] credentials = proxyUrl.getUserInfo().split(":");
+            if (credentials.length > 0) {
+                final String username = URLDecoder.decode(credentials[0], StandardCharsets.UTF_8);
+                final Pair<String, String> domainUsername = parseProxyUsername(username);
+                Optional.ofNullable(domainUsername.getLeft()).ifPresent(proxyCfg::setDomain);
+                Optional.ofNullable(domainUsername.getRight()).ifPresent(proxyCfg::setUsername);
+            }
+            if (credentials.length == 2) {
+                proxyCfg.setPassword(URLDecoder.decode(credentials[1], StandardCharsets.UTF_8));
+            }
+        }
+
+        return proxyCfg;
+    }
+
+    /**
+     * Optionally parses usernames if they are NTLM formatted.
+     * <p>
+     * Ported from Dependency-Track's {@code ManagedHttpClientFactory}.
+     *
+     * @param username The username to parse
+     * @return A {@link Pair} consisting of the user's domain (if any), and the username
+     * @see <a href="https://github.com/DependencyTrack/dependency-track/blob/4.7.0/src/main/java/org/dependencytrack/common/ManagedHttpClientFactory.java">Source</a>
+     */
+    private static Pair<String, String> parseProxyUsername(final String username) {
+        if (username.contains("\\")) {
+            return Pair.of(
+                    username.substring(0, username.indexOf("\\")),
+                    username.substring(username.indexOf("\\") + 1)
+            );
+        }
+        return Pair.of(null, username);
+    }
+
+}

--- a/alpine-common/src/test/java/alpine/common/util/ProxyConfigTest.java
+++ b/alpine-common/src/test/java/alpine/common/util/ProxyConfigTest.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Set;
+
+public class ProxyConfigTest {
+
+    @Test
+    public void shouldProxyWithoutHostTest() throws MalformedURLException {
+        final var proxyCfg = new ProxyConfig();
+        Assert.assertFalse(proxyCfg.shouldProxy(null));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("ftp://example.com:21")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:443")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:8080")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.com:443")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.example.com:80")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://fooexample.com:80")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.bar.example.com:8000")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.net:80")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.example.net:80")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://example.org:443")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8080")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8000")));
+    }
+
+    @Test
+    public void shouldProxyWithoutNoProxyTest() throws MalformedURLException {
+        final var proxyCfg = new ProxyConfig();
+        proxyCfg.setHost("proxy.example.com");
+        Assert.assertFalse(proxyCfg.shouldProxy(null));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("ftp://example.com:21")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://example.com:443")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://example.com:8080")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://www.example.com:443")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://foo.example.com:80")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://fooexample.com:80")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://foo.bar.example.com:8000")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://www.example.net:80")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://foo.example.net:80")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://example.org:443")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8080")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8000")));
+    }
+
+    @Test
+    public void shouldProxyWithNoProxyTest() throws MalformedURLException {
+        final var proxyCfg = new ProxyConfig();
+        proxyCfg.setHost("proxy.example.com");
+        proxyCfg.setNoProxy(Set.of("localhost:443", "127.0.0.1:8080", "example.com", "www.example.net"));
+        Assert.assertFalse(proxyCfg.shouldProxy(null));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("ftp://example.com:21")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:443")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:8080")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.com:443")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.example.com:80")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://fooexample.com:80")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.bar.example.com:8000")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.net:80")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://foo.example.net:80")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://example.org:443")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8080")));
+        Assert.assertTrue(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8000")));
+    }
+
+    @Test
+    public void shouldProxyWithNoProxyStarTest() throws MalformedURLException {
+        final var proxyCfg = new ProxyConfig();
+        proxyCfg.setHost("proxy.example.com");
+        proxyCfg.setNoProxy(Set.of("*"));
+        Assert.assertFalse(proxyCfg.shouldProxy(null));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("ftp://example.com:21")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:443")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:8080")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.com:443")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.example.com:80")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://fooexample.com:80")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.bar.example.com:8000")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.net:80")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.example.net:80")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://example.org:443")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8080")));
+        Assert.assertFalse(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8000")));
+    }
+
+}

--- a/alpine-common/src/test/java/alpine/common/util/ProxyUtilTest.java
+++ b/alpine-common/src/test/java/alpine/common/util/ProxyUtilTest.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.common.util;
+
+import alpine.Config;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ProxyUtilTest {
+
+    @Test
+    public void fromConfigTest() {
+        Assert.assertNull(ProxyUtil.fromConfig(null));
+        Assert.assertNull(ProxyUtil.fromConfig(mock(Config.class)));
+
+        var configMock = mock(Config.class);
+        when(configMock.getProperty(eq(Config.AlpineKey.HTTP_PROXY_ADDRESS))).thenReturn("proxy.http.example.com");
+        when(configMock.getPropertyAsInt(eq(Config.AlpineKey.HTTP_PROXY_PORT))).thenReturn(6666);
+        when(configMock.getProperty(eq(Config.AlpineKey.HTTP_PROXY_USERNAME))).thenReturn("domain\\username");
+        when(configMock.getPropertyOrFile(eq(Config.AlpineKey.HTTP_PROXY_PASSWORD))).thenReturn("pa$%word");
+        when(configMock.getProperty(eq(Config.AlpineKey.NO_PROXY))).thenReturn("acme.com,foo.bar:1234");
+
+        final var proxyCfg = ProxyUtil.fromConfig(configMock);
+        Assert.assertNotNull(proxyCfg);
+        Assert.assertEquals("proxy.http.example.com", proxyCfg.getHost());
+        Assert.assertEquals(6666, proxyCfg.getPort());
+        Assert.assertEquals("domain", proxyCfg.getDomain());
+        Assert.assertEquals("username", proxyCfg.getUsername());
+        Assert.assertEquals("pa$%word", proxyCfg.getPassword());
+        Assert.assertEquals(Set.of("acme.com", "foo.bar:1234"), proxyCfg.getNoProxy());
+    }
+
+    @Test
+    public void fromEnvironmentTest() {
+        Assert.assertNull(ProxyUtil.fromEnvironment(null));
+        Assert.assertNull(ProxyUtil.fromEnvironment(Collections.emptyMap()));
+
+        final var proxyCfg = ProxyUtil.fromEnvironment(Map.of(
+                "https_proxy", "http://proxy.https.example.com:6443",
+                "http_proxy", "http://proxy.http.example.com:6666",
+                "no_proxy", "acme.com,foo.bar:1234"
+        ));
+        Assert.assertNotNull(proxyCfg);
+        Assert.assertEquals("proxy.https.example.com", proxyCfg.getHost());
+        Assert.assertEquals(6443, proxyCfg.getPort());
+        Assert.assertNull(proxyCfg.getDomain());
+        Assert.assertNull(proxyCfg.getUsername());
+        Assert.assertNull(proxyCfg.getPassword());
+        Assert.assertEquals(Set.of("acme.com", "foo.bar:1234"), proxyCfg.getNoProxy());
+    }
+
+    @Test
+    public void fromEnvironmentWithAuthenticationTest() {
+        final var proxyCfg = ProxyUtil.fromEnvironment(Map.of(
+                "http_proxy", "http://domain%5Cusername:pa$%25word@proxy.http.example.com:6666"
+        ));
+        Assert.assertNotNull(proxyCfg);
+        Assert.assertEquals("proxy.http.example.com", proxyCfg.getHost());
+        Assert.assertEquals(6666, proxyCfg.getPort());
+        Assert.assertEquals("domain", proxyCfg.getDomain());
+        Assert.assertEquals("username", proxyCfg.getUsername());
+        Assert.assertEquals("pa$%word", proxyCfg.getPassword());
+        Assert.assertNull(proxyCfg.getNoProxy());
+    }
+
+}

--- a/alpine-common/src/test/resources/alpine.version
+++ b/alpine-common/src/test/resources/alpine.version
@@ -1,0 +1,4 @@
+name=${project.name}
+version=${project.version}
+timestamp=${timestamp}
+uuid=${project.build.uuid}


### PR DESCRIPTION
As usage of proxies can be necessary for Alpine-internal functionality too, and proxy behavior should behave consistently, moving this logic to Alpine is necessary.

Signed-off-by: nscuro <nscuro@protonmail.com>