### PR TITLE
Revert logback update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <lib.jsr353-impl.version>1.1.4</lib.jsr353-impl.version>
         <lib.jsr353-spec.version>1.1.4</lib.jsr353-spec.version>
         <lib.jstl.version>1.2.5</lib.jstl.version>
-        <lib.logback.version>1.4.5</lib.logback.version>
+        <lib.logback.version>1.2.11</lib.logback.version>
         <lib.micrometer.version>1.9.4</lib.micrometer.version>
         <lib.nimbus-oauth2-oidc-sdk.version>9.43.1</lib.nimbus-oauth2-oidc-sdk.version>
         <lib.owasp.encoder.version>1.2.3</lib.owasp.encoder.version>


### PR DESCRIPTION
logback 1.4.x targets Jakarta APIs (`jakarta.*`), while 1.3.x targets Java EE APIs (`javax.*`).

Both 1.4.x and 1.3.x require SLF4J 2.0.x: https://logback.qos.ch/news.html

<img width="767" alt="image" src="https://user-images.githubusercontent.com/5693141/221410989-57b1763b-5a84-4915-837c-5a0e9bdc613e.png">

With the current `master` of Alpine, the logging in Dependency-Track no longer works.

I tried downgrading logback to 1.3.5, and updating SLF4J to 2.0.6, but that causes build errors during DataNucleus enhancement:

```
[ERROR] Failed to execute goal org.datanucleus:datanucleus-maven-plugin:6.0.0-release:enhance (default) on project dependency-track: Execution default of goal org.datanucleus:datanucleus-maven-plugin:6.0.0-release:enhance failed: An API incompatibility was encountered while executing org.datanucleus:datanucleus-maven-plugin:6.0.0-release:enhance: java.lang.ExceptionInInitializerError: null
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.datanucleus:datanucleus-maven-plugin:6.0.0-release
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/Users/nscur0/.m2/repository/org/datanucleus/datanucleus-maven-plugin/6.0.0-release/datanucleus-maven-plugin-6.0.0-release.jar
[ERROR] urls[1] = file:/Users/nscur0/.m2/repository/org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.jar
[ERROR] urls[2] = file:/Users/nscur0/.m2/repository/org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar
[ERROR] urls[3] = file:/Users/nscur0/.m2/repository/javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar
[ERROR] urls[4] = file:/Users/nscur0/.m2/repository/org/eclipse/sisu/org.eclipse.sisu.inject/0.3.4/org.eclipse.sisu.inject-0.3.4.jar
[ERROR] urls[5] = file:/Users/nscur0/.m2/repository/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar
[ERROR] urls[6] = file:/Users/nscur0/.m2/repository/org/apache/xbean/xbean-reflect/3.7/xbean-reflect-3.7.jar
[ERROR] urls[7] = file:/Users/nscur0/.m2/repository/com/google/collections/google-collections/1.0/google-collections-1.0.jar
[ERROR] Number of foreign imports: 1
[ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
[ERROR] 
[ERROR] -----------------------------------------------------
[ERROR] : Cannot invoke "org.slf4j.IMarkerFactory.getDetachedMarker(String)" because "org.slf4j.MarkerFactory.MARKER_FACTORY" is null
[ERROR] -> [Help 1]
```

That error log is not really helpful, so until we found a solution to this, I think the safest bet is to revert to 1.2.11 again.