### PR TITLE
Persist email of OIDC users

### DIFF
--- a/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
+++ b/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
@@ -164,6 +164,7 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
         final OidcUser user = getObjectById(OidcUser.class, transientUser.getId());
         pm.currentTransaction().begin();
         user.setSubjectIdentifier(transientUser.getSubjectIdentifier());
+        user.setEmail(transientUser.getEmail());
         pm.currentTransaction().commit();
         return pm.getObjectById(OidcUser.class, user.getId());
     }

--- a/alpine-model/src/main/java/alpine/model/OidcUser.java
+++ b/alpine-model/src/main/java/alpine/model/OidcUser.java
@@ -67,9 +67,11 @@ public class OidcUser implements Serializable, Principal, UserPrincipal {
     @Pattern(regexp = "[\\P{Cc}]+", message = "The subject identifier must not contain control characters")
     private String subjectIdentifier;
 
+    @Persistent
+    @Column(name = "EMAIL", allowsNull = "true")
     @Size(max = 255)
     @Pattern(regexp = "[\\P{Cc}]+", message = "The email address must not contain control characters")
-    private transient String email; // not persisted - will be retrieved from the identity provider
+    private String email;
 
     @Persistent(table = "OIDCUSERS_TEAMS", defaultFetchGroup = "true")
     @Join(column = "OIDCUSERS_ID")


### PR DESCRIPTION
This PR adjusts the OIDC implementation to persist the email address of users, similar to how https://github.com/stevespringett/Alpine/pull/450 did it for LDAP.

There was no particular reason for not persisting the email back when I implemented OIDC, other than "the LDAP implementation does not do it, too". 

In the DT community we're seeing that the email not being persistent is counter-intuitive and prevents certain use cases, see https://github.com/DependencyTrack/dependency-track/issues/2647