### PR TITLE
Allow customization of DataNucleus via pass-through properties

### DIFF
--- a/alpine-common/pom.xml
+++ b/alpine-common/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/alpine-common/src/test/java/alpine/ConfigTest.java
+++ b/alpine-common/src/test/java/alpine/ConfigTest.java
@@ -1,0 +1,68 @@
+package alpine;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+
+import java.net.URL;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigTest {
+
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    @After
+    public void tearDown() {
+        Config.reset();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        Config.getInstance().init(); // Ensure we're not affecting other tests
+    }
+
+    @Test
+    public void testGetPassThroughPropertiesEmpty() {
+        Config.getInstance().init();
+
+        assertThat(Config.getInstance().getPassThroughProperties("datanucleus")).isEmpty();
+    }
+
+    @Test
+    public void testGetPassThroughProperties() {
+        final URL propertiesUrl = ConfigTest.class.getResource("/Config_testGetPassThroughProperties.properties");
+        assertThat(propertiesUrl).isNotNull();
+
+        System.setProperty("alpine.application.properties", propertiesUrl.getPath());
+
+        Config.getInstance().init();
+
+        environmentVariables.set("ALPINE_FOO", "fromEnv1");
+        environmentVariables.set("ALPINE_DATANUCLEUS", "fromEnv2");
+        environmentVariables.set("ALPINE_DATANUCLEUS_FOO", "fromEnv3");
+        environmentVariables.set("ALPINE_DATANUCLEUS_FOO_BAR", "fromEnv4");
+        environmentVariables.set("ALPINE_DATA_NUCLEUS_FOO", "fromEnv5");
+        environmentVariables.set("DATANUCLEUS_FOO", "fromEnv6");
+        environmentVariables.set("ALPINE_DATANUCLEUS_FROM_ENV", "fromEnv7");
+        environmentVariables.set("alpine_datanucleus_from_env_lowercase", "fromEnv8");
+        environmentVariables.set("Alpine_DataNucleus_From_Env_MixedCase", "fromEnv9");
+
+        assertThat(Config.getInstance().getPassThroughProperties("datanucleus"))
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        "datanucleus.foo", "fromEnv3", // ENV takes precedence over properties
+                        "datanucleus.foo.bar", "fromEnv4", // ENV takes precedence over properties
+                        "datanucleus.from.env", "fromEnv7",
+                        "datanucleus.from.props", "fromProps7"
+                ));
+    }
+
+}

--- a/alpine-common/src/test/resources/Config_testGetPassThroughProperties.properties
+++ b/alpine-common/src/test/resources/Config_testGetPassThroughProperties.properties
@@ -1,0 +1,9 @@
+alpine.foo=fromProps1
+alpine.datanucleus=fromProps2
+alpine.datanucleus.foo=fromProps3
+alpine.datanucleus.foo.bar=fromProps4
+alpine.data.nucleus.foo=fromProps5
+datanucleus.foo=fromProps6
+alpine.datanucleus.from.props=fromProps7
+ALPINE.DATANUCLEUS.FROM.PROPS.UPPERCASE=fromProps8
+Alpine.DataNucleus.From.Props.MixedCase=fromProps9

--- a/alpine-server/src/main/java/alpine/server/persistence/PersistenceManagerFactory.java
+++ b/alpine-server/src/main/java/alpine/server/persistence/PersistenceManagerFactory.java
@@ -62,6 +62,11 @@ public class PersistenceManagerFactory implements IPersistenceManagerFactory, Se
         LOGGER.info("Initializing persistence framework");
 
         final var dnProps = new Properties();
+
+        // Apply pass-through properties first. Settings that are hardcoded, or have dedicated
+        // AlpineKeys, must still take precedence over pass-through properties.
+        dnProps.putAll(Config.getInstance().getPassThroughProperties("datanucleus"));
+
         dnProps.put(PropertyNames.PROPERTY_SCHEMA_AUTOCREATE_DATABASE, "true");
         dnProps.put(PropertyNames.PROPERTY_SCHEMA_AUTOCREATE_TABLES, "true");
         dnProps.put(PropertyNames.PROPERTY_SCHEMA_AUTOCREATE_COLUMNS, "true");


### PR DESCRIPTION
This change is mostly meant to address #493, but may be useful for other use cases as well.

Due to the sheer amount of configuration options in DataNucleus (and potentially other frameworks), it is not practical to add `AlpineKey`s for all of them.

With this change, it is possible to disable the DataNucleus L2 cache by either:

* Setting the property `alpine.datanucleus.cache.level2.type=none` in `application.properties`, or
* Setting the environment variable `ALPINE_DATANUCLEUS_CACHE_LEVEL2_TYPE=none`

Closes #493