### PR TITLE
Add API key prefix support

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -176,7 +176,8 @@ public class Config {
         CORS_EXPOSE_HEADERS                    ("alpine.cors.expose.headers",        "Origin, Content-Type, Authorization, X-Requested-With, Content-Length, Accept, Origin, X-Api-Key, X-Total-Count"),
         CORS_ALLOW_CREDENTIALS                 ("alpine.cors.allow.credentials",     true),
         CORS_MAX_AGE                           ("alpine.cors.max.age",               3600),
-        WATCHDOG_LOGGING_INTERVAL              ("alpine.watchdog.logging.interval",  0);
+        WATCHDOG_LOGGING_INTERVAL              ("alpine.watchdog.logging.interval",  0),
+        API_KEY_PREFIX                         ("alpine.api.key.prefix",             "alpine_");
 
 
         private String propertyName;

--- a/alpine-infra/src/main/java/alpine/security/ApiKeyGenerator.java
+++ b/alpine-infra/src/main/java/alpine/security/ApiKeyGenerator.java
@@ -18,6 +18,8 @@
  */
 package alpine.security;
 
+import alpine.Config;
+
 import java.security.SecureRandom;
 
 /**
@@ -35,7 +37,7 @@ public final class ApiKeyGenerator {
     private ApiKeyGenerator() { }
 
     /**
-     * Generates a 32 character cryptographically secure API key.
+     * Generates a prefixed cryptographically secure API key of 32 characters not including the prefix length.
      *  @return a String representation of the API key
      * @since 1.0.0
      */
@@ -44,8 +46,8 @@ public final class ApiKeyGenerator {
     }
 
     /**
-     * Generates a cryptographically secure API key of the specified length.
-     * @param chars the length of the API key to generate
+     * Generates a cryptographically secure API key of the specified length having the configured API key prefix.
+     * @param chars the length of the API key to generate not including the prefix length
      * @return a String representation of the API key
      */
     public static String generate(final int chars) {
@@ -57,6 +59,11 @@ public final class ApiKeyGenerator {
             }
             buff[i] = VALID_CHARACTERS[secureRandom.nextInt(VALID_CHARACTERS.length)];
         }
-        return new String(buff);
+
+        return getApiKeyPrefix() + String.valueOf(buff);
+    }
+
+    private static String getApiKeyPrefix() {
+        return Config.getInstance().getProperty(Config.AlpineKey.API_KEY_PREFIX);
     }
 }

--- a/alpine-infra/src/test/java/alpine/security/ApiKeyGeneratorTest.java
+++ b/alpine-infra/src/test/java/alpine/security/ApiKeyGeneratorTest.java
@@ -18,25 +18,29 @@
  */
 package alpine.security;
 
+import alpine.Config;
 import org.junit.Assert;
 import org.junit.Test;
 import java.util.regex.Pattern;
 
 public class ApiKeyGeneratorTest {
 
-    private Pattern pattern = Pattern.compile("^[A-Za-z0-9]*$");
+    private Pattern pattern = Pattern.compile("^[A-Za-z_0-9]*$");
+    private String apiKeyPrefix = Config.getInstance().getProperty(Config.AlpineKey.API_KEY_PREFIX);
 
     @Test
     public void defaultGenerateTest() {
         String key = ApiKeyGenerator.generate();
-        Assert.assertEquals(32, key.length());
+        Assert.assertEquals(apiKeyPrefix.length() + 32, key.length());
+        Assert.assertTrue(key.startsWith(apiKeyPrefix));
         Assert.assertTrue(pattern.matcher(key).matches());
     }
 
     @Test
     public void generateTest() {
         String key = ApiKeyGenerator.generate(4096);
-        Assert.assertEquals(4096, key.length());
+        Assert.assertEquals(apiKeyPrefix.length() + 4096, key.length());
+        Assert.assertTrue(key.startsWith(apiKeyPrefix));
         Assert.assertTrue(pattern.matcher(key).matches());
     }
 }

--- a/alpine-model/src/main/java/alpine/model/ApiKey.java
+++ b/alpine-model/src/main/java/alpine/model/ApiKey.java
@@ -59,7 +59,8 @@ public class ApiKey implements Serializable, Principal {
     @Column(name = "APIKEY", allowsNull = "false")
     @NotNull
     @Size(min = 32, max = 255)
-    @Pattern(regexp = RegexSequence.Definition.ALPHA_NUMERIC, message = "The API key must contain only alpha and/or numeric characters")
+    @Pattern(regexp = RegexSequence.Definition.WORD_CHARS,
+            message = "The API key must contain only alpha, numeric and/or underscore characters")
     private String key;
 
     @Persistent(table = "APIKEYS_TEAMS", defaultFetchGroup = "true")

--- a/alpine-model/src/main/java/alpine/model/ApiKey.java
+++ b/alpine-model/src/main/java/alpine/model/ApiKey.java
@@ -18,6 +18,7 @@
  */
 package alpine.model;
 
+import alpine.Config;
 import alpine.common.validation.RegexSequence;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -48,6 +49,7 @@ import java.util.List;
 public class ApiKey implements Serializable, Principal {
 
     private static final long serialVersionUID = 1582714693932260365L;
+    private static final String prefix = Config.getInstance().getProperty(Config.AlpineKey.API_KEY_PREFIX);
 
     @PrimaryKey
     @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
@@ -87,6 +89,25 @@ public class ApiKey implements Serializable, Principal {
     }
 
     /**
+     * Masks all key characters except the prefix and last four characters with *. If the key does not have the
+     * currently configured prefix, do not return it.
+     * @return Masked key.
+     */
+    public String getMaskedKey() {
+        final StringBuilder maskedKey = new StringBuilder();
+
+        // if key does not have the current prefix, do not return a prefix
+        if (key.startsWith(prefix))
+            maskedKey.append(prefix);
+
+        // mask all characters except the last four
+        maskedKey.append("*".repeat(key.length() - maskedKey.length() - 4));
+        maskedKey.append(key.substring(key.length() - 4));
+
+        return maskedKey.toString();
+    }
+
+    /**
      * Do not use - only here to satisfy Principal implementation requirement.
      * @deprecated use {@link UserPrincipal#getUsername()}
      * @return a String presentation of the username
@@ -94,9 +115,7 @@ public class ApiKey implements Serializable, Principal {
     @Deprecated
     @JsonIgnore
     public String getName() {
-        String key = getKey();
-
-        return key.substring(0, 4) + "****" + key.substring(key.length() - 4);
+        return getMaskedKey();
     }
 
     public List<Team> getTeams() {

--- a/alpine-model/src/test/java/alpine/model/ApiKeyTest.java
+++ b/alpine-model/src/test/java/alpine/model/ApiKeyTest.java
@@ -18,6 +18,7 @@
  */
 package alpine.model;
 
+import alpine.Config;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -25,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ApiKeyTest {
+    final String prefix = Config.getInstance().getProperty(Config.AlpineKey.API_KEY_PREFIX);
 
     @Test
     public void idTest() {
@@ -35,10 +37,43 @@ public class ApiKeyTest {
 
     @Test
     public void keyTest() {
-        ApiKey key = new ApiKey();
-        key.setKey("12345678901234567890");
-        Assert.assertEquals("12345678901234567890", key.getKey());
-        Assert.assertEquals("1234****7890", key.getName());
+        {
+            ApiKey key = new ApiKey();
+            key.setKey("12345678901234567890");
+            Assert.assertEquals("12345678901234567890", key.getKey());
+            Assert.assertEquals("****************7890", key.getName());
+        }
+        {
+            ApiKey key = new ApiKey();
+            key.setKey(prefix + "12345678901234567890");
+            Assert.assertEquals(prefix + "12345678901234567890", key.getKey());
+            Assert.assertEquals(prefix + "****************7890", key.getName());
+        }
+    }
+
+    @Test
+    public void maskTest() {
+        {
+            ApiKey key = new ApiKey();
+            key.setKey("12345678901234567890");
+            Assert.assertEquals("****************7890", key.getMaskedKey());
+        }
+        {
+            ApiKey key = new ApiKey();
+            key.setKey("1234ABCabc+_=!?-*");
+            Assert.assertEquals("*************!?-*", key.getMaskedKey());
+        }
+        {
+            ApiKey key = new ApiKey();
+            key.setKey("1234");
+            Assert.assertEquals("1234", key.getMaskedKey());
+        }
+        {
+            // test with prefix
+            ApiKey key = new ApiKey();
+            key.setKey(prefix + "1234567890");
+            Assert.assertEquals(prefix + "******7890", key.getMaskedKey());
+        }
     }
 
     @Test

--- a/alpine-server/src/main/java/alpine/server/filters/AuthorizationFilter.java
+++ b/alpine-server/src/main/java/alpine/server/filters/AuthorizationFilter.java
@@ -77,9 +77,8 @@ public class AuthorizationFilter implements ContainerRequestFilter {
                             return;
                         }
                     }
-                    final String maskedApiKey = apiKey.getKey().replaceAll("\\w(?=\\w{4})", "*");
                     LOGGER.info(SecurityMarkers.SECURITY_FAILURE, "Unauthorized access attempt made by API Key "
-                            + maskedApiKey + " to " + ((ContainerRequest) requestContext).getRequestUri().toString());
+                            + apiKey.getMaskedKey() + " to " + ((ContainerRequest) requestContext).getRequestUri().toString());
                 } else {
                     UserPrincipal user = null;
                     if (principal instanceof ManagedUser) {

--- a/example/src/main/resources/application.properties
+++ b/example/src/main/resources/application.properties
@@ -37,6 +37,12 @@ alpine.data.directory=~/.alpine-example
 # alpine.private.key.path=/var/run/secrets/private.key
 # alpine.public.key.path=/var/run/secrets/public.key
 
+# Optional
+# Defines the prefix to be used for API keys. A maximum prefix length of 251
+# characters is supported.
+# The prefix may also be left empty. Default is "alpine_".
+# alpine.api.key.prefix=alpine_
+
 # Required
 # Defines the interval (in seconds) to log general heath information.
 # If value equals 0, watchdog logging will be disabled.


### PR DESCRIPTION
This adds support for API key prefixes to assist secret scanning. The default API key prefix is "dta_" and may be changed with the alpine.secret.api.keyprefix property.

## Addressed Issue
See https://github.com/DependencyTrack/dependency-track/issues/2543

## Additional Details
This does not invalidate old API keys that do not use the new format. The user is free to entirely disable the prefix by setting the property to an empty string.