### PR TITLE
Add ability to customize the Micrometer `MeterRegistry`

### DIFF
--- a/alpine-common/src/main/java/alpine/common/metrics/MeterRegistryCustomizer.java
+++ b/alpine-common/src/main/java/alpine/common/metrics/MeterRegistryCustomizer.java
@@ -1,0 +1,17 @@
+package alpine.common.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.util.function.Consumer;
+
+/**
+ * A customizer for Micrometer {@link MeterRegistry}.
+ * <p>
+ * Customizers must be deployed as service providers in order to be discoverable.
+ * Refer to the {@link java.util.ServiceLoader} documentation for details.
+ *
+ * @since 2.3.0
+ */
+@FunctionalInterface
+public interface MeterRegistryCustomizer extends Consumer<MeterRegistry> {
+}

--- a/alpine-common/src/test/java/alpine/common/metrics/MetricsTest.java
+++ b/alpine-common/src/test/java/alpine/common/metrics/MetricsTest.java
@@ -1,0 +1,35 @@
+package alpine.common.metrics;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetricsTest {
+
+    public static class TestMeterRegistryCustomizer implements MeterRegistryCustomizer {
+
+        @Override
+        public void accept(final MeterRegistry meterRegistry) {
+            meterRegistry.config().meterFilter(MeterFilter.commonTags(Tags.of("commonKey", "commonValue")));
+        }
+
+    }
+
+    @Test
+    public void testCustomized() {
+        var registry = Metrics.customized(new SimpleMeterRegistry());
+       
+        Gauge.builder("foo", () -> 123)
+                .tag("foo", "bar")
+                .register(registry);
+
+        assertThat(registry.getMetersAsString())
+                .isEqualTo("foo(GAUGE)[commonKey='commonValue', foo='bar']; value=123.0");
+    }
+
+}

--- a/alpine-common/src/test/resources/META-INF/services/alpine.common.metrics.MeterRegistryCustomizer
+++ b/alpine-common/src/test/resources/META-INF/services/alpine.common.metrics.MeterRegistryCustomizer
@@ -1,0 +1,1 @@
+alpine.common.metrics.MetricsTest$TestMeterRegistryCustomizer


### PR DESCRIPTION
Because it is crucial that filters are registered *before* the individual meters, `ServiceLoader` is used to load and apply all customizations immediately after the registry is created.

Closes #500