### PR TITLE
Allow paths of public/private key pair to be customized

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -101,6 +101,8 @@ public class Config {
         WORKER_THREAD_MULTIPLIER               ("alpine.worker.thread.multiplier",   4),
         DATA_DIRECTORY                         ("alpine.data.directory",             "~/.alpine"),
         SECRET_KEY_PATH                        ("alpine.secret.key.path",            null),
+        PRIVATE_KEY_PATH                       ("alpine.private.key.path",           null),
+        PUBLIC_KEY_PATH                        ("alpine.public.key.path",            null),
         DATABASE_MODE                          ("alpine.database.mode",              "embedded"),
         DATABASE_PORT                          ("alpine.database.port",              9092),
         DATABASE_URL                           ("alpine.database.url",               "jdbc:h2:mem:alpine"),

--- a/alpine-infra/src/main/java/alpine/security/crypto/KeyManager.java
+++ b/alpine-infra/src/main/java/alpine/security/crypto/KeyManager.java
@@ -181,6 +181,16 @@ public final class KeyManager {
             if (secretKeyPath != null) {
                 return Paths.get(secretKeyPath).toFile();
             }
+        } else if (keyType == KeyType.PRIVATE) {
+            final String privateKeyPath = Config.getInstance().getProperty(Config.AlpineKey.PRIVATE_KEY_PATH);
+            if (privateKeyPath != null) {
+                return Paths.get(privateKeyPath).toFile();
+            }
+        } else if (keyType == KeyType.PUBLIC) {
+            final String publicKeyPath = Config.getInstance().getProperty(Config.AlpineKey.PUBLIC_KEY_PATH);
+            if (publicKeyPath != null) {
+                return Paths.get(publicKeyPath).toFile();
+            }
         }
         return new File(Config.getInstance().getDataDirectorty()
                 + File.separator

--- a/example/src/main/resources/application.properties
+++ b/example/src/main/resources/application.properties
@@ -30,6 +30,13 @@ alpine.data.directory=~/.alpine-example
 # Default is "<alpine.data.directory>/keys/secret.key".
 # alpine.secret.key.path=/var/run/secrets/secret.key
 
+# Optional
+# Defines the paths to the public-private key pair to be used for signing and verifying digital signatures.
+# The keys will be generated upon first startup if they do not exist.
+# Defaults are "<alpine.data.directory>/keys/private.key" and "<alpine.data.directory>/keys/public.key".
+# alpine.private.key.path=/var/run/secrets/private.key
+# alpine.public.key.path=/var/run/secrets/public.key
+
 # Required
 # Defines the interval (in seconds) to log general heath information.
 # If value equals 0, watchdog logging will be disabled.


### PR DESCRIPTION
Similarly to what was done for the secret key in #437, this allows pre-generated keys mounted into the application's container to be used.

This is necessary to support deployments where multiple app instances must share the same keys.