### PR TITLE
Allow for drainage of `EventService` and `NotificationService` on shutdown

### DIFF
--- a/alpine-common/src/main/java/alpine/common/util/ExecutorUtil.java
+++ b/alpine-common/src/main/java/alpine/common/util/ExecutorUtil.java
@@ -1,0 +1,36 @@
+package alpine.common.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Utility methods for working with {@link ExecutorService}s.
+ *
+ * @since 2.3.0
+ */
+public final class ExecutorUtil {
+
+    public record ExecutorStats(boolean terminated, Integer queueSize, Integer activeThreads) {
+    }
+
+    private ExecutorUtil() {
+    }
+
+    /**
+     * Gathers {@link ExecutorStats} about a given {@link ExecutorService}.
+     *
+     * @param executor The {@link ExecutorService} to collect stats for
+     * @return The collected {@link ExecutorStats}
+     */
+    public static ExecutorStats getExecutorStats(final ExecutorService executor) {
+        if (executor instanceof final ThreadPoolExecutor tpExecutor) {
+            return new ExecutorStats(tpExecutor.isTerminated(), tpExecutor.getQueue().size(), tpExecutor.getActiveCount());
+        } else if (executor instanceof final ForkJoinPool fjpExecutor) {
+            return new ExecutorStats(fjpExecutor.isTerminated(), fjpExecutor.getQueuedSubmissionCount(), fjpExecutor.getActiveThreadCount());
+        }
+
+        return new ExecutorStats(executor.isTerminated(), null, null);
+    }
+
+}

--- a/alpine-infra/src/main/java/alpine/event/framework/EventService.java
+++ b/alpine-infra/src/main/java/alpine/event/framework/EventService.java
@@ -19,11 +19,14 @@
 package alpine.event.framework;
 
 import alpine.common.logging.Logger;
-import alpine.common.util.ThreadUtil;
 import alpine.common.metrics.Metrics;
+import alpine.common.util.ThreadUtil;
 import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A publish/subscribe (pub/sub) event service that provides the ability to publish events and
@@ -50,7 +53,9 @@ public final class EventService extends BaseEventService {
                 .namingPattern(EXECUTOR_NAME + "-%d")
                 .uncaughtExceptionHandler(new LoggableUncaughtExceptionHandler())
                 .build();
-        EXECUTOR = Executors.newFixedThreadPool(ThreadUtil.determineNumberOfWorkerThreads(), factory);
+        final int threadPoolSize = ThreadUtil.determineNumberOfWorkerThreads();
+        EXECUTOR = new ThreadPoolExecutor(threadPoolSize, threadPoolSize, 0L, TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(), factory);
         INSTANCE.setExecutorService(EXECUTOR);
         INSTANCE.setLogger(LOGGER);
         Metrics.registerExecutorService(EXECUTOR, EXECUTOR_NAME);

--- a/alpine-infra/src/main/java/alpine/event/framework/IEventService.java
+++ b/alpine-infra/src/main/java/alpine/event/framework/IEventService.java
@@ -18,6 +18,7 @@
  */
 package alpine.event.framework;
 
+import java.time.Duration;
 import java.util.UUID;
 
 /**
@@ -74,6 +75,18 @@ public interface IEventService {
      * @since 1.2.0
      */
     void shutdown();
+
+    /**
+     * Shuts down this {@link IEventService}, and waits for already queued events to be processed
+     * until a given {@code timeout} elapses.
+     * <p>
+     * Events enqueued during shutdown will not be processed.
+     *
+     * @param timeout The {@link Duration} to wait for event processing to complete
+     * @return {@code true} when all queued events were processed prior to {@code timeout} elapsing, otherwise {@code false}
+     * @since 2.3.0
+     */
+    boolean shutdown(final Duration timeout);
 
     /**
      * Determines if the specified event is currently being processed. Processing may indicate the

--- a/alpine-infra/src/main/java/alpine/event/framework/SingleThreadedEventService.java
+++ b/alpine-infra/src/main/java/alpine/event/framework/SingleThreadedEventService.java
@@ -39,7 +39,7 @@ import java.util.concurrent.Executors;
 public final class SingleThreadedEventService extends BaseEventService {
 
     private static final SingleThreadedEventService INSTANCE = new SingleThreadedEventService();
-    private static final Logger LOGGER = Logger.getLogger(EventService.class);
+    private static final Logger LOGGER = Logger.getLogger(SingleThreadedEventService.class);
     private static final ExecutorService EXECUTOR;
     private static final String EXECUTOR_NAME = "Alpine-SingleThreadedEventService";
 

--- a/alpine-infra/src/main/java/alpine/notification/INotificationService.java
+++ b/alpine-infra/src/main/java/alpine/notification/INotificationService.java
@@ -18,6 +18,8 @@
  */
 package alpine.notification;
 
+import java.time.Duration;
+
 /**
  * Defines a NotificationService. All notification services must be singletons and implement a static
  * getInstance() method.
@@ -78,4 +80,17 @@ public interface INotificationService {
      * @since 1.3.0
      */
     void shutdown();
+
+    /**
+     * Shuts down this {@link INotificationService}, and waits for already queued notifications
+     * to be processed until a given {@code timeout} elapses.
+     * <p>
+     * Notifications enqueued during shutdown will not be processed.
+     *
+     * @param timeout The {@link Duration} to wait for notification processing to complete
+     * @return {@code true} when all queued notifications were processed prior to {@code timeout} elapsing, otherwise {@code false}
+     * @since 2.3.0
+     */
+    boolean shutdown(final Duration timeout);
+
 }


### PR DESCRIPTION
Using solely `IEventService#shutdown` and `NotificationService#shutdown` will cause queued events and notifications to be lost. This is problematic when event and notification processing must be relied upon.

It is now possible to provide a timeout to the `shutdown` method. Alpine will wait for `ExecutorService` queues to be drained until the timeout is exceeded. A status message about remaining queued items, and active thread counts is logged every 5sec during shutdown.

Ideally, the order of subsystems being shut down would be:

* Web app / REST API; Stopping new events from being emitted via user interactions
* Eventing; Processing all events enqueued prior to Web app / REST API shutdown
* Notifications; Processing all notifications emitted during event processing

While this is not a perfect solution, and it does not *guarantee* no event loss, it makes it less likely.