### PR TITLE
Bump Jersey from `2.38` to `2.40`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <lib.jaxb.core.version>2.3.0.1</lib.jaxb.core.version>
         <lib.jaxb.impl.version>2.3.6</lib.jaxb.impl.version>
         <lib.jdo.api.version>3.2.1</lib.jdo.api.version>
-        <lib.jersey.version>2.38</lib.jersey.version>
+        <lib.jersey.version>2.40</lib.jersey.version>
         <lib.json-unit.version>2.37.0</lib.json-unit.version>
         <lib.jsp.api.version>2.2</lib.jsp.api.version>
         <lib.jsonwebtoken.version>0.9.1</lib.jsonwebtoken.version>


### PR DESCRIPTION
Jersey 2.40 includes support for Java 21: https://projects.eclipse.org/projects/ee4j.jersey/releases/2.40