### PR TITLE
Revert `logstash-logback-encoder` to 7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,8 @@
         <lib.jsr353-spec.version>1.1.4</lib.jsr353-spec.version>
         <lib.jstl.version>1.2.5</lib.jstl.version>
         <lib.logback.version>1.2.11</lib.logback.version>
-        <lib.logstash-logback-encoder.version>7.4</lib.logstash-logback-encoder.version> <!-- logstash-logback-encoder >= v7.4 requires logback v2 -->
+        <!-- Keep at 7.3! logstash-logback-encoder >= v7.4 requires logback v2 -->
+        <lib.logstash-logback-encoder.version>7.3</lib.logstash-logback-encoder.version>
         <lib.micrometer.version>1.11.4</lib.micrometer.version>
         <lib.microprofile-health-api.version>3.1</lib.microprofile-health-api.version>
         <lib.nimbus-oauth2-oidc-sdk.version>10.15</lib.nimbus-oauth2-oidc-sdk.version>


### PR DESCRIPTION
Version 7.4 requires logback v2 which Alpine currently does not support.

Using the JSON encoder with v7.4 currently fails, see https://github.com/DependencyTrack/dependency-track/issues/3127