### PR TITLE
Bump embedded Jetty to `10.0.18` and remove unused `jetty-webapp-logging` dependency

### DIFF
--- a/alpine-executable-war/pom.xml
+++ b/alpine-executable-war/pom.xml
@@ -34,7 +34,6 @@
         <!-- Dependency Versions -->
         <lib.servlet-api.version>4.0.2</lib.servlet-api.version>
         <lib.jetty.version>10.0.18</lib.jetty.version>
-        <lib.jetty.webapp.logging>9.4.27</lib.jetty.webapp.logging>
     </properties>
 
     <dependencies>
@@ -53,11 +52,6 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-webapp</artifactId>
             <version>${lib.jetty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-webapp-logging</artifactId>
-            <version>${lib.jetty.webapp.logging}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/alpine-executable-war/pom.xml
+++ b/alpine-executable-war/pom.xml
@@ -33,7 +33,7 @@
 
         <!-- Dependency Versions -->
         <lib.servlet-api.version>4.0.2</lib.servlet-api.version>
-        <lib.jetty.version>10.0.14</lib.jetty.version>
+        <lib.jetty.version>10.0.18</lib.jetty.version>
         <lib.jetty.webapp.logging>9.4.27</lib.jetty.webapp.logging>
     </properties>
 


### PR DESCRIPTION
The Jetty update resolves CVE-2023-40167 and GHSA-58qw-p7qm-5rvh.