### PR TITLE
Ensure `ChainableEvent`s are being removed from tracked events

### DIFF
--- a/alpine-infra/src/main/java/alpine/event/framework/BaseEventService.java
+++ b/alpine-infra/src/main/java/alpine/event/framework/BaseEventService.java
@@ -138,12 +138,11 @@ public abstract class BaseEventService implements IEventService {
                             }
                         }
                     }
+                } finally {
+                    if (event instanceof ChainableEvent) {
+                        removeTrackedEvent((ChainableEvent)event);
+                    }
                 }
-
-                if (event instanceof ChainableEvent) {
-                    removeTrackedEvent((ChainableEvent)event);
-                }
-
             });
         }
         recordPublishedMetric(event);


### PR DESCRIPTION
If an unhandled exception occurred, the event would previously not be removed from the `chainTracker` map.

This can be problematic for events marked as singleton, as consecutive dispatches of the same event would be ignored, as the previously failed event was never removed from the tracking map.