### PR TITLE
Fix path resolution of `~` on Windows

### DIFF
--- a/alpine-common/src/main/java/alpine/common/util/PathUtil.java
+++ b/alpine-common/src/main/java/alpine/common/util/PathUtil.java
@@ -43,7 +43,7 @@ public class PathUtil {
         if (path == null) {
             return null;
         }
-        if (path.startsWith("~" + File.separator)) {
+        if (path.startsWith("~/") || path.startsWith("~\\")) {
             return SystemUtil.getUserHome() + path.substring(1);
         }
         return path;


### PR DESCRIPTION
`PathUtil#resolve` was previously checking for the occurrence of `"~" + File.separator` to determine whether `~` shall be expanded to the user's home directory.

`File.separator` is `/` on UNIX and `\` on Windows. The default of `alpine.data.directory` is `~/.alpine`, causing the aforementioned check to always fail on Windows.