### PR TITLE
Add ability to disable automatic schema management and migrations

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -110,6 +110,7 @@ public class Config {
         DATABASE_USERNAME                      ("alpine.database.username",          "sa"),
         DATABASE_PASSWORD                      ("alpine.database.password",          ""),
         DATABASE_PASSWORD_FILE                 ("alpine.database.password.file",     null),
+        DATABASE_MIGRATION_ENABLED             ("alpine.database.migration.enabled", true),
         DATABASE_POOL_ENABLED                  ("alpine.database.pool.enabled",      true),
         @Deprecated
         DATABASE_POOL_MAX_SIZE                 ("alpine.database.pool.max.size",     20),

--- a/example/src/main/resources/application.properties
+++ b/example/src/main/resources/application.properties
@@ -87,6 +87,12 @@ alpine.database.driver=org.h2.Driver
 # alpine.database.password_file=
 
 # Optional
+# Specifies if database migrations should be performed automatically on startup, based on
+# the defined object model of the application. This may be disabled when migrations are
+# managed externally, e.g. via Flyway or Liquibase.
+alpine.database.migration.enabled=true
+
+# Optional
 # Specifies if database connection pooling is enabled.
 alpine.database.pool.enabled=true
 


### PR DESCRIPTION
When using external schema management solutions like Flyway or Liquibase, having DataNucleus / Alpine perform schema modifications automatically can cause undesired side effects.

The new property `alpine.database.migration.enabled` defaults to `true` to preserve existing behavior.