### PR TITLE
Fix broken logging due to logback update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
       update-types:
       - version-update:semver-major
       - version-update:semver-minor
+    # logback-classic 1.3.x requires SLF4J 2.x, but SLF4J 2.x breaks datanucleus-maven-plugin.
+    # logback-classic 1.4.x uses Jakarta EE namespace whereas Alpine is still on legacy Java EE.
+    - dependency-name: ch.qos.logback:logback-classic
+      update-types:
+      - version-update:semver-major
+      - version-update:semver-minor
 
   - package-ecosystem: "maven"
     directory: "/executable-war/"

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <lib.jsr353-impl.version>1.1.4</lib.jsr353-impl.version>
         <lib.jsr353-spec.version>1.1.4</lib.jsr353-spec.version>
         <lib.jstl.version>1.2.5</lib.jstl.version>
-        <lib.logback.version>1.4.13</lib.logback.version>
+        <lib.logback.version>1.2.13</lib.logback.version>
         <!-- Keep at 7.3! logstash-logback-encoder >= v7.4 requires logback v2 -->
         <lib.logstash-logback-encoder.version>7.3</lib.logstash-logback-encoder.version>
         <lib.micrometer.version>1.11.4</lib.micrometer.version>


### PR DESCRIPTION
Logging broke due to the logback update to 1.4.x. The only observable output now is:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

Tried using logback 1.3.x, but that requires SLF4j 2.x which then caused the DataNucleus Maven plugin to fail.

logback 1.4.x cannot be used until we migrate to Jakarta EE, which is tracked in https://github.com/stevespringett/Alpine/issues/402.

logback 1.2.x is still supported and received its last update on Dec 1st. I updated the dependabot config to only suggest new bugfix versions.