### PR TITLE
oidc: default team

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -30,7 +30,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
@@ -161,6 +163,7 @@ public class Config {
         OIDC_USER_PROVISIONING                 ("alpine.oidc.user.provisioning",    false),
         OIDC_TEAM_SYNCHRONIZATION              ("alpine.oidc.team.synchronization", false),
         OIDC_TEAMS_CLAIM                       ("alpine.oidc.teams.claim",       "groups"),
+        OIDC_TEAMS_DEFAULT                     ("alpine.oidc.teams.default",         null),
         HTTP_PROXY_ADDRESS                     ("alpine.http.proxy.address",         null),
         HTTP_PROXY_PORT                        ("alpine.http.proxy.port",            null),
         HTTP_PROXY_USERNAME                    ("alpine.http.proxy.username",        null),
@@ -480,6 +483,22 @@ public class Config {
      */
     public boolean getPropertyAsBoolean(Key key) {
         return "true".equalsIgnoreCase(getProperty(key));
+    }
+
+    /**
+     * Return the configured value for the specified Key.
+     * @param key The Key to return the configuration for
+     * @return a list of the comma-separated values of the configuration,
+     *         or an empty list otherwise
+     * @since 2.2.5
+     */
+    public List<String> getPropertyAsList(Key key) {
+        String property = getProperty(key);
+        if (property == null) {
+            return Collections.emptyList();
+        } else {
+            return List.of(property.split(","));
+        }
     }
 
     /**

--- a/alpine-server/src/main/java/alpine/server/auth/OidcAuthenticationService.java
+++ b/alpine-server/src/main/java/alpine/server/auth/OidcAuthenticationService.java
@@ -235,9 +235,10 @@ public class OidcAuthenticationService implements AuthenticationService {
         if (config.getPropertyAsBoolean(Config.AlpineKey.OIDC_TEAM_SYNCHRONIZATION)) {
             LOGGER.debug("Synchronizing teams for user " + user.getUsername());
             return qm.synchronizeTeamMembership(user, profile.getGroups());
+        } else {
+            // Only apply default teams during auto-provisioning, not on later updates:
+            return qm.addUserToTeams(user, config.getPropertyAsList(Config.AlpineKey.OIDC_TEAMS_DEFAULT));
         }
-
-        return user;
     }
 
 }


### PR DESCRIPTION
The assignment of (a) default team(s) happens once during user provisioning, to give administrators a chance to change the teams for a user later.

The assignment of (a) default team(s) does not go through the indirection of an OIDC Group, and expects the administrator to directly specify the teams the user should be a member of by default. This is intentional, because otherwise it could be confusing what would happen when the mapping between OIDC Groups and Teams changes after a user was already provisioned. This also matches the UI, which primarily shows (and allows changes to) the 'Team membership' of a user on the 'OpenID Connect Users' page, rather than showing the OIDC Group membership.

Implements https://github.com/stevespringett/Alpine/issues/411