### PR TITLE
Bump `logback` to 1.3.14 and `slf4j-api` to 2.0.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,6 @@ updates:
       update-types:
       - version-update:semver-major
       - version-update:semver-minor
-    # logback-classic 1.3.x requires SLF4J 2.x, but SLF4J 2.x breaks datanucleus-maven-plugin.
     # logback-classic 1.4.x uses Jakarta EE namespace whereas Alpine is still on legacy Java EE.
     - dependency-name: ch.qos.logback:logback-classic
       update-types:

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <lib.jsr353-impl.version>1.1.4</lib.jsr353-impl.version>
         <lib.jsr353-spec.version>1.1.4</lib.jsr353-spec.version>
         <lib.jstl.version>1.2.5</lib.jstl.version>
-        <lib.logback.version>1.2.13</lib.logback.version>
+        <lib.logback.version>1.3.14</lib.logback.version>
         <!-- Keep at 7.3! logstash-logback-encoder >= v7.4 requires logback v2 -->
         <lib.logstash-logback-encoder.version>7.3</lib.logstash-logback-encoder.version>
         <lib.micrometer.version>1.11.4</lib.micrometer.version>
@@ -192,7 +192,7 @@
         <lib.nimbus-oauth2-oidc-sdk.version>10.15</lib.nimbus-oauth2-oidc-sdk.version>
         <lib.owasp.encoder.version>1.2.3</lib.owasp.encoder.version>
         <lib.owasp.security-logging.version>1.1.7</lib.owasp.security-logging.version>
-        <lib.slf4j.version>1.7.36</lib.slf4j.version>
+        <lib.slf4j.version>2.0.12</lib.slf4j.version>
         <lib.swagger.jersey.version>1.6.11</lib.swagger.jersey.version>
         <!-- Unit test libraries -->
         <lib.junit.version>4.13.2</lib.junit.version>
@@ -695,6 +695,17 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <dependencies>
+                            <!--
+                              The DataNucleus Enhancer still depends on SLF4J 1.x and will
+                              fail if that version is not present.
+                            -->
+                            <dependency>
+                                <groupId>org.slf4j</groupId>
+                                <artifactId>slf4j-api</artifactId>
+                                <version>1.7.36</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
logback 1.2.x is no longer receiving updates, and logback 1.3.x upwards depends on SLF4J 2.x.

The DataNucleus plugin fails when SLF4J 1.x is no longer present. Hence, SLF4J 1.x was added as a dependency specifically for the plugin.

Tested with Dependency-Track 4.11.0-SNAPSHOT. Both standard format and JSON format continue to work with this change.