### PR TITLE
Use lambdas for transaction scoping; Don't reload objects after commit

### DIFF
--- a/alpine-infra/pom.xml
+++ b/alpine-infra/pom.xml
@@ -78,8 +78,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/alpine-infra/src/main/java/alpine/persistence/AbstractAlpineQueryManager.java
+++ b/alpine-infra/src/main/java/alpine/persistence/AbstractAlpineQueryManager.java
@@ -18,12 +18,11 @@
  */
 package alpine.persistence;
 
-import alpine.common.logging.Logger;
-import alpine.resources.AlpineRequest;
 import alpine.common.validation.RegexSequence;
-import io.jsonwebtoken.lang.Collections;
+import alpine.resources.AlpineRequest;
 import org.apache.commons.collections4.CollectionUtils;
 import org.datanucleus.api.jdo.JDOQuery;
+
 import javax.jdo.FetchPlan;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
@@ -38,6 +37,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 
 /**
  * Base persistence manager that implements AutoCloseable so that the PersistenceManager will
@@ -48,7 +48,6 @@ import java.util.UUID;
  */
 public abstract class AbstractAlpineQueryManager implements AutoCloseable {
 
-    private static final Logger LOGGER = Logger.getLogger(AbstractAlpineQueryManager.class);
     private static final ServiceLoader<IPersistenceManagerFactory> IpmfServiceLoader = ServiceLoader.load(IPersistenceManagerFactory.class);
 
     protected final Principal principal;
@@ -145,84 +144,18 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
     }
 
     /**
-     * Wrapper around {@link Query#execute()} that adds transparent support for
-     * pagination and ordering of results via {@link #decorate(Query)}.
-     * @param query the JDO Query object to execute
-     * @return a PaginatedResult object
-     * @since 1.0.0
-     */
-    public PaginatedResult execute(final Query query) {
-        final long count = getCount(query);
-        decorate(query);
-        return new PaginatedResult()
-                .objects(query.execute())
-                .total(count);
-    }
-
-    /**
-     * Wrapper around {@link Query#execute(Object)} that adds transparent support for
-     * pagination and ordering of results via {@link #decorate(Query)}.
-     * @param query the JDO Query object to execute
-     * @param p1 the value of the first parameter declared.
-     * @return a PaginatedResult object
-     * @since 1.0.0
-     */
-    public PaginatedResult execute(final Query query, final Object p1) {
-        final long count = getCount(query, p1);
-        decorate(query);
-        return new PaginatedResult()
-                .objects(query.execute(p1))
-                .total(count);
-    }
-
-    /**
-     * Wrapper around {@link Query#execute(Object, Object)} that adds transparent support for
-     * pagination and ordering of results via {@link #decorate(Query)}.
-     * @param query the JDO Query object to execute
-     * @param p1 the value of the first parameter declared.
-     * @param p2 the value of the second parameter declared.
-     * @return a PaginatedResult object
-     * @since 1.0.0
-     */
-    public PaginatedResult execute(final Query query, final Object p1, final Object p2) {
-        final long count = getCount(query, p1, p2);
-        decorate(query);
-        return new PaginatedResult()
-                .objects(query.execute(p1, p2))
-                .total(count);
-    }
-
-    /**
-     * Wrapper around {@link Query#execute(Object, Object, Object)} that adds transparent support for
-     * pagination and ordering of results via {@link #decorate(Query)}.
-     * @param query the JDO Query object to execute
-     * @param p1 the value of the first parameter declared.
-     * @param p2 the value of the second parameter declared.
-     * @param p3 the value of the third parameter declared.
-     * @return a PaginatedResult object
-     * @since 1.0.0
-     */
-    public PaginatedResult execute(final Query query, final Object p1, final Object p2, final Object p3) {
-        final long count = getCount(query, p1, p2, p3);
-        decorate(query);
-        return new PaginatedResult()
-                .objects(query.execute(p1, p2, p3))
-                .total(count);
-    }
-
-    /**
      * Wrapper around {@link Query#executeWithArray(Object...)} that adds transparent support for
      * pagination and ordering of results via {@link #decorate(Query)}.
      * @param query the JDO Query object to execute
-     * @param parameters the <code>Object</code> array with all of the parameters
+     * @param parameters the <code>Object</code> array with all the parameters
      * @return a PaginatedResult object
      * @since 1.0.0
      */
-    public PaginatedResult execute(final Query query, final Object... parameters) {
+    public PaginatedResult execute(final Query<?> query, final Object... parameters) {
         final long count = getCount(query, parameters);
         decorate(query);
         return new PaginatedResult()
-                .objects(query.executeWithArray(parameters))
+                .objects(executeAndCloseWithArray(query, parameters))
                 .total(count);
     }
 
@@ -230,15 +163,15 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * Wrapper around {@link Query#executeWithMap(Map)} that adds transparent support for
      * pagination and ordering of results via {@link #decorate(Query)}.
      * @param query the JDO Query object to execute
-     * @param parameters the <code>Map</code> containing all of the parameters.
+     * @param parameters the <code>Map</code> containing all the parameters.
      * @return a PaginatedResult object
      * @since 1.0.0
      */
-    public PaginatedResult execute(final Query query, final Map parameters) {
+    public PaginatedResult execute(final Query<?> query, final Map<String, Object> parameters) {
         final long count = getCount(query, parameters);
         decorate(query);
         return new PaginatedResult()
-                .objects(query.executeWithMap(parameters))
+                .objects(executeAndCloseWithMap(query, parameters))
                 .total(count);
     }
 
@@ -262,7 +195,7 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @return a Collection of objects
      * @since 1.0.0
      */
-    public Query decorate(final Query query) {
+    public <T> Query<T> decorate(final Query<T> query) {
         // Clear the result to fetch if previously specified (i.e. by getting count)
         query.setResult(null);
         if (pagination != null && pagination.isPaginated()) {
@@ -273,7 +206,7 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
         if (orderBy != null && RegexSequence.Pattern.STRING_IDENTIFIER.matcher(orderBy).matches() && orderDirection != OrderDirection.UNSPECIFIED) {
             // Check to see if the specified orderBy field is defined in the class being queried.
             boolean found = false;
-            final org.datanucleus.store.query.Query iq = ((JDOQuery) query).getInternalQuery();
+            final org.datanucleus.store.query.Query<T> iq = ((JDOQuery<T>) query).getInternalQuery();
             final String candidateField = orderBy.contains(".") ? orderBy.substring(0, orderBy.indexOf('.')) : orderBy;
             for (final Field field: iq.getCandidateClass().getDeclaredFields()) {
                 if (candidateField.equals(field.getName())) {
@@ -293,17 +226,17 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * This method is performant in that the objects are not actually retrieved, only
      * the count.
      * @param query the query to return a count from
+     * @param parameters the <code>Object</code> array with all the parameters
      * @return the number of items
      * @since 1.0.0
      */
-    public long getCount(final Query query) {
-        //query.addExtension("datanucleus.query.resultSizeMethod", "count");
-        final String ordering = ((JDOQuery) query).getInternalQuery().getOrdering();
-        query.setResult("count(id)");
-        query.setOrdering(null);
-        final long count = (Long) query.execute();
-        query.setOrdering(ordering);
-        return count;
+    public long getCount(final Query<?> query, final Object... parameters) {
+        final org.datanucleus.store.query.Query<?> internalQuery = ((JDOQuery<?>) query).getInternalQuery();
+        final Query<?> countQuery = pm.newQuery(internalQuery.getCandidateClass());
+        countQuery.setFilter(internalQuery.getFilter());
+        countQuery.setParameters(parameters);
+        countQuery.setResult("count(this)");
+        return executeAndCloseResultUnique(countQuery, Long.class);
     }
 
     /**
@@ -311,92 +244,17 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * This method is performant in that the objects are not actually retrieved, only
      * the count.
      * @param query the query to return a count from
-     * @param p1 the value of the first parameter declared.
+     * @param parameters the <code>Map</code> containing all the parameters.
      * @return the number of items
      * @since 1.0.0
      */
-    public long getCount(final Query query, final Object p1) {
-        final String ordering = ((JDOQuery) query).getInternalQuery().getOrdering();
-        query.setResult("count(id)");
-        query.setOrdering(null);
-        final long count = (Long) query.execute(p1);
-        query.setOrdering(ordering);
-        return count;
-    }
-
-    /**
-     * Returns the number of items that would have resulted from returning all object.
-     * This method is performant in that the objects are not actually retrieved, only
-     * the count.
-     * @param query the query to return a count from
-     * @param p1 the value of the first parameter declared.
-     * @param p2 the value of the second parameter declared.
-     * @return the number of items
-     * @since 1.0.0
-     */
-    public long getCount(final Query query, final Object p1, final Object p2) {
-        final String ordering = ((JDOQuery) query).getInternalQuery().getOrdering();
-        query.setResult("count(id)");
-        query.setOrdering(null);
-        final long count = (Long) query.execute(p1, p2);
-        query.setOrdering(ordering);
-        return count;
-    }
-
-    /**
-     * Returns the number of items that would have resulted from returning all object.
-     * This method is performant in that the objects are not actually retrieved, only
-     * the count.
-     * @param query the query to return a count from
-     * @param p1 the value of the first parameter declared.
-     * @param p2 the value of the second parameter declared.
-     * @param p3 the value of the third parameter declared.
-     * @return the number of items
-     * @since 1.0.0
-     */
-    public long getCount(final Query query, final Object p1, final Object p2, final Object p3) {
-        final String ordering = ((JDOQuery) query).getInternalQuery().getOrdering();
-        query.setResult("count(id)");
-        query.setOrdering(null);
-        final long count = (Long) query.execute(p1, p2, p3);
-        query.setOrdering(ordering);
-        return count;
-    }
-
-    /**
-     * Returns the number of items that would have resulted from returning all object.
-     * This method is performant in that the objects are not actually retrieved, only
-     * the count.
-     * @param query the query to return a count from
-     * @param parameters the <code>Object</code> array with all of the parameters
-     * @return the number of items
-     * @since 1.0.0
-     */
-    public long getCount(final Query query, final Object... parameters) {
-        final String ordering = ((JDOQuery) query).getInternalQuery().getOrdering();
-        query.setResult("count(id)");
-        query.setOrdering(null);
-        final long count = (Long) query.executeWithArray(parameters);
-        query.setOrdering(ordering);
-        return count;
-    }
-
-    /**
-     * Returns the number of items that would have resulted from returning all object.
-     * This method is performant in that the objects are not actually retrieved, only
-     * the count.
-     * @param query the query to return a count from
-     * @param parameters the <code>Map</code> containing all of the parameters.
-     * @return the number of items
-     * @since 1.0.0
-     */
-    public long getCount(final Query query, final Map parameters) {
-        final String ordering = ((JDOQuery) query).getInternalQuery().getOrdering();
-        query.setResult("count(id)");
-        query.setOrdering(null);
-        final long count = (Long) query.executeWithMap(parameters);
-        query.setOrdering(ordering);
-        return count;
+    public long getCount(final Query<?> query, final Map<String, Object> parameters) {
+        final org.datanucleus.store.query.Query<?> internalQuery = ((JDOQuery<?>) query).getInternalQuery();
+        final Query<?> countQuery = pm.newQuery(internalQuery.getCandidateClass());
+        countQuery.setFilter(internalQuery.getFilter());
+        countQuery.setNamedParameters(parameters);
+        countQuery.setResult("count(this)");
+        return executeAndCloseResultUnique(countQuery, Long.class);
     }
 
     /**
@@ -409,10 +267,9 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @since 1.0.0
      */
     public <T> long getCount(final Class<T> cls) {
-        final Query query = pm.newQuery(cls);
-        //query.addExtension("datanucleus.query.resultSizeMethod", "count");
+        final Query<T> query = pm.newQuery(cls);
         query.setResult("count(id)");
-        return (Long) query.execute();
+        return executeAndCloseResultUnique(query, Long.class);
     }
 
     /**
@@ -421,14 +278,8 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @param <T> the type to return
      * @return the persisted object
      */
-    @SuppressWarnings("unchecked")
     public <T> T persist(T object) {
-        pm.currentTransaction().begin();
-        pm.makePersistent(object);
-        pm.currentTransaction().commit();
-        pm.getFetchPlan().setDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS);
-        pm.refresh(object);
-        return object;
+        return callInTransaction(() -> pm.makePersistent(object));
     }
 
     /**
@@ -437,14 +288,8 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @param <T> the type to return
      * @return the persisted objects
      */
-    @SuppressWarnings("unchecked")
     public <T> T[] persist(T... pcs) {
-        pm.currentTransaction().begin();
-        pm.makePersistentAll(pcs);
-        pm.currentTransaction().commit();
-        pm.getFetchPlan().setDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS);
-        pm.refreshAll(pcs);
-        return pcs;
+        return callInTransaction(() -> pm.makePersistentAll(pcs));
     }
 
     /**
@@ -453,14 +298,8 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @param <T> the type to return
      * @return the persisted objects
      */
-    @SuppressWarnings("unchecked")
-    public <T> Collection<T> persist(Collection pcs) {
-        pm.currentTransaction().begin();
-        pm.makePersistentAll(pcs);
-        pm.currentTransaction().commit();
-        pm.getFetchPlan().setDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS);
-        pm.refreshAll(pcs);
-        return pcs;
+    public <T> Collection<T> persist(Collection<T> pcs) {
+        return callInTransaction(() -> pm.makePersistentAll(pcs));
     }
 
     /**
@@ -469,9 +308,7 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @since 1.0.0
      */
     public void delete(Object... objects) {
-        pm.currentTransaction().begin();
-        pm.deletePersistentAll(objects);
-        pm.currentTransaction().commit();
+        runInTransaction(() -> pm.deletePersistentAll(objects));
     }
 
     /**
@@ -479,25 +316,29 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @param collection a collection of one or more objects to delete
      * @since 1.0.0
      */
-    public void delete(Collection collection) {
-        pm.currentTransaction().begin();
-        pm.deletePersistentAll(collection);
-        pm.currentTransaction().commit();
+    public void delete(Collection<?> collection) {
+        runInTransaction(() -> pm.deletePersistentAll(collection));
     }
 
     /**
      * Refreshes and detaches an object by its ID.
      * @param <T> A type parameter. This type will be returned
-     * @param clazz the persistence class to retrive the ID for
+     * @param clazz the persistence class to retrieve the ID for
      * @param id the object id to retrieve
      * @return an object of the specified type
      * @since 1.3.0
      */
     public <T> T detach(Class<T> clazz, Object id) {
-        pm.getFetchPlan().setDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS);
-        return pm.detachCopy(pm.getObjectById(clazz, id));
+        try (var ignored = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
+            return pm.detachCopy(pm.getObjectById(clazz, id));
+        }
     }
 
+    public <T> T detach(final T object) {
+        try (var ignored = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
+            return pm.detachCopy(object);
+        }
+    }
 
     /**
      * Refreshes and detaches an objects.
@@ -507,8 +348,9 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @since 1.3.0
      */
     public <T> List<T> detach(List<T> pcs) {
-        pm.getFetchPlan().setDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS);
-        return new ArrayList<>(pm.detachCopyAll(pcs));
+        try (var ignored = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
+            return new ArrayList<>(pm.detachCopyAll(pcs));
+        }
     }
 
     /**
@@ -519,14 +361,44 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @since 1.3.0
      */
     public <T> Set<T> detach(Set<T> pcs) {
-        pm.getFetchPlan().setDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS);
-        return new LinkedHashSet<>(pm.detachCopyAll(pcs));
+        try (var ignored = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
+            return new LinkedHashSet<>(pm.detachCopyAll(pcs));
+        }
+    }
+
+    /**
+     * Transition {@code object} into the transient state, detaching it from the persistence context.
+     * This does <strong>not</strong> create a copy of {@code object}!
+     *
+     * @param object The object to make transient
+     * @param <T>    The type of {@code object}
+     * @return The transitioned object
+     * @see <a href="https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#lifecycle">JDO Object Lifecycle</a>
+     */
+    public <T> T makeTransient(final T object) {
+        pm.makeTransient(object);
+        return object;
+    }
+
+    /**
+     * Transitions {@code collection} into the transient state, detaching its items from the persistence context.
+     * This does <strong>not</strong> create a copy of {@code collection}, or the items within it!
+     *
+     * @param collection The collection to make transient
+     * @param <C>        The type of {@code collection}
+     * @param <T>        The type of the items within {@code collection}
+     * @return The transitioned collection
+     * @see <a href="https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#lifecycle">JDO Object Lifecycle</a>
+     */
+    public <T, C extends Collection<T>> C makeTransientAll(final C collection) {
+        pm.makeTransientAll(collection);
+        return collection;
     }
 
     /**
      * Retrieves an object by its ID.
      * @param <T> A type parameter. This type will be returned
-     * @param clazz the persistence class to retrive the ID for
+     * @param clazz the persistence class to retrieve the ID for
      * @param id the object id to retrieve
      * @return an object of the specified type
      * @since 1.0.0
@@ -538,27 +410,25 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
     /**
      * Retrieves an object by its UUID.
      * @param <T> A type parameter. This type will be returned
-     * @param clazz the persistence class to retrive the ID for
+     * @param clazz the persistence class to retrieve the ID for
      * @param uuid the uuid of the object to retrieve
      * @return an object of the specified type
      * @since 1.0.0
      */
-    @SuppressWarnings("unchecked")
     public <T> T getObjectByUuid(Class<T> clazz, UUID uuid) {
-        final Query query = pm.newQuery(clazz, "uuid == :uuid");
-        final List<T> result = (List<T>) query.execute(uuid);
-        return Collections.isEmpty(result) ? null : result.get(0);
+        final Query<T> query = pm.newQuery(clazz, "uuid == :uuid");
+        query.setParameters(uuid);
+        return executeAndCloseUnique(query);
     }
 
     /**
      * Retrieves an object by its UUID.
      * @param <T> A type parameter. This type will be returned
-     * @param clazz the persistence class to retrive the ID for
+     * @param clazz the persistence class to retrieve the ID for
      * @param uuid the uuid of the object to retrieve
      * @return an object of the specified type
      * @since 1.0.0
      */
-    @SuppressWarnings("unchecked")
     public <T> T getObjectByUuid(Class<T> clazz, String uuid) {
         return getObjectByUuid(clazz, UUID.fromString(uuid));
     }
@@ -566,28 +436,28 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
     /**
      * Retrieves an object by its UUID.
      * @param <T> A type parameter. This type will be returned
-     * @param clazz the persistence class to retrive the ID for
+     * @param clazz the persistence class to retrieve the ID for
      * @param uuid the uuid of the object to retrieve
-     * @param fetchGroup the JDO fetchgroup to use when making the query
+     * @param fetchGroup the JDO fetch group to use when making the query
      * @return an object of the specified type
      * @since 1.0.0
      */
-    @SuppressWarnings("unchecked")
     public <T> T getObjectByUuid(Class<T> clazz, UUID uuid, String fetchGroup) {
-        pm.getFetchPlan().addGroup(fetchGroup);
-        return getObjectByUuid(clazz, uuid);
+        final Query<T> query = pm.newQuery(clazz, "uuid == :uuid");
+        query.getFetchPlan().addGroup(fetchGroup);
+        query.setParameters(uuid);
+        return executeAndCloseUnique(query);
     }
 
     /**
      * Retrieves an object by its UUID.
      * @param <T> A type parameter. This type will be returned
-     * @param clazz the persistence class to retrive the ID for
+     * @param clazz the persistence class to retrieve the ID for
      * @param uuid the uuid of the object to retrieve
-     * @param fetchGroup the JDO fetchgroup to use when making the query
+     * @param fetchGroup the JDO fetch group to use when making the query
      * @return an object of the specified type
      * @since 1.0.0
      */
-    @SuppressWarnings("unchecked")
     public <T> T getObjectByUuid(Class<T> clazz, String uuid, String fetchGroup) {
         return getObjectByUuid(clazz, UUID.fromString(uuid), fetchGroup);
     }
@@ -624,6 +494,179 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
 
     public PersistenceManager getPersistenceManager() {
         return pm;
+    }
+
+    /**
+     * Execute a {@link Callable} within the context of a transaction.
+     *
+     * @param options  The {@link Transaction.Options} to apply to the transaction
+     * @param callable The {@link Callable} to execute
+     * @param <T>      Type of the result returned by {@code callable}
+     * @return The result of {@code callable} after transaction commit
+     */
+    public <T> T callInTransaction(final Transaction.Options options, final Callable<T> callable) {
+        return Transaction.call(pm, options, callable);
+    }
+
+    /**
+     * Execute a {@link Callable} within the context of a transaction.
+     *
+     * @param callable The {@link Callable} to execute
+     * @param <T>      Type of the result returned by {@code callable}
+     * @return The result of {@code callable} after transaction commit
+     */
+    public <T> T callInTransaction(final Callable<T> callable) {
+        return callInTransaction(Transaction.defaultOptions(), callable);
+    }
+
+    /**
+     * Execute a {@link Runnable} within the context of a transaction.
+     *
+     * @param options  The {@link Transaction.Options} to apply to the transaction
+     * @param runnable The {@link Callable} to execute
+     */
+    public void runInTransaction(final Transaction.Options options, final Runnable runnable) {
+        callInTransaction(options, () -> {
+            runnable.run();
+            return null;
+        });
+    }
+
+    /**
+     * Execute a {@link Runnable} within the context of a transaction.
+     *
+     * @param runnable The {@link Callable} to execute
+     */
+    public void runInTransaction(final Runnable runnable) {
+        runInTransaction(Transaction.defaultOptions(), runnable);
+    }
+
+    /**
+     * Wrapper around {@link Query#execute()} that closes the {@link Query}
+     * after its result has been retrieved, to prevent resource leakage.
+     *
+     * @param query The {@link Query} to execute
+     * @return The {@link Query}'s result
+     */
+    protected Object executeAndClose(final Query<?> query) {
+        try {
+            final Object result = query.execute();
+            if (result instanceof final Collection<?> resultCollection) {
+                return new ArrayList<>(resultCollection);
+            }
+
+            return result;
+        } finally {
+            query.closeAll();
+        }
+    }
+
+    /**
+     * Wrapper around {@link Query#executeWithArray(Object...)} that closes the {@link Query}
+     * after its result has been retrieved, to prevent resource leakage.
+     *
+     * @param query      The {@link Query} to execute
+     * @param parameters The query parameters
+     * @return The {@link Query}'s result
+     */
+    protected Object executeAndCloseWithArray(final Query<?> query, final Object... parameters) {
+        try {
+            final Object result = query.executeWithArray(parameters);
+            if (result instanceof final Collection<?> resultCollection) {
+                return new ArrayList<>(resultCollection);
+            }
+
+            return result;
+        } finally {
+            query.closeAll();
+        }
+    }
+
+    /**
+     * Wrapper around {@link Query#executeWithMap(Map)} that closes the {@link Query}
+     * after its result has been retrieved, to prevent resource leakage.
+     *
+     * @param query      The {@link Query} to execute
+     * @param parameters The query parameters
+     * @return The {@link Query}'s result
+     */
+    protected Object executeAndCloseWithMap(final Query<?> query, final Map<String, Object> parameters) {
+        try {
+            final Object result = query.executeWithMap(parameters);
+            if (result instanceof final Collection<?> resultCollection) {
+                return new ArrayList<>(resultCollection);
+            }
+
+            return result;
+        } finally {
+            query.closeAll();
+        }
+    }
+
+    /**
+     * Wrapper around {@link Query#executeUnique()} that closes the {@link Query}
+     * after its result has been retrieved, to prevent resource leakage.
+     *
+     * @param query The {@link Query} to execute
+     * @param <T>   Type of the {@link Query}'s result
+     * @return The {@link Query}'s result
+     */
+    protected <T> T executeAndCloseUnique(final Query<T> query) {
+        try {
+            return query.executeUnique();
+        } finally {
+            query.closeAll();
+        }
+    }
+
+    /**
+     * Wrapper around {@link Query#executeList()} that closes the {@link Query}
+     * after its result has been retrieved, to prevent resource leakage.
+     *
+     * @param query The {@link Query} to execute
+     * @param <T>   Type of the {@link Query}'s result
+     * @return The {@link Query}'s result
+     */
+    protected <T> List<T> executeAndCloseList(final Query<T> query) {
+        try {
+            return new ArrayList<>(query.executeList());
+        } finally {
+            query.closeAll();
+        }
+    }
+
+    /**
+     * Wrapper around {@link Query#executeResultUnique()} that closes the {@link Query}
+     * after its result has been retrieved, to prevent resource leakage.
+     *
+     * @param query       The {@link Query} to execute
+     * @param resultClass The {@link Class} of the {@link Query}'s result
+     * @param <T>         Type of the {@link Query}'s result
+     * @return The {@link Query}'s result
+     */
+    protected <T> T executeAndCloseResultUnique(final Query<?> query, final Class<T> resultClass) {
+        try {
+            return query.executeResultUnique(resultClass);
+        } finally {
+            query.closeAll();
+        }
+    }
+
+    /**
+     * Wrapper around {@link Query#executeResultList()} that closes the {@link Query}
+     * after its result has been retrieved, to prevent resource leakage.
+     *
+     * @param query       The {@link Query} to execute
+     * @param resultClass The {@link Class} of the {@link Query}'s result
+     * @param <T>         Type of the {@link Query}'s result
+     * @return The {@link Query}'s result
+     */
+    protected <T> List<T> executeAndCloseResultList(final Query<T> query, final Class<T> resultClass) {
+        try {
+            return new ArrayList<>(query.executeResultList(resultClass));
+        } finally {
+            query.closeAll();
+        }
     }
 
 }

--- a/alpine-infra/src/main/java/alpine/persistence/JdoProperties.java
+++ b/alpine-infra/src/main/java/alpine/persistence/JdoProperties.java
@@ -76,6 +76,7 @@ public final class JdoProperties {
         properties.put(PropertyNames.PROPERTY_SCHEMA_AUTOCREATE_CONSTRAINTS, "true");
         properties.put(PropertyNames.PROPERTY_SCHEMA_GENERATE_DATABASE_MODE, "create");
         properties.put(PropertyNames.PROPERTY_QUERY_JDOQL_ALLOWALL, "true");
+        properties.put(PropertyNames.PROPERTY_RETAIN_VALUES, "true");
         return properties;
     }
 }

--- a/alpine-infra/src/main/java/alpine/persistence/ScopedCustomization.java
+++ b/alpine-infra/src/main/java/alpine/persistence/ScopedCustomization.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.persistence;
+
+import org.datanucleus.api.jdo.JDOPersistenceManager;
+
+import javax.jdo.PersistenceManager;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class ScopedCustomization implements AutoCloseable {
+
+    private final JDOPersistenceManager pm;
+    private final Deque<Runnable> cleanUpItems = new ArrayDeque<>();
+
+    public ScopedCustomization(final PersistenceManager pm) {
+        if (pm instanceof final JDOPersistenceManager jdoPm) {
+            this.pm = jdoPm;
+        } else {
+            throw new IllegalArgumentException("Unsupported PersistenceManager type: %s"
+                    .formatted(pm.getClass().getName()));
+        }
+    }
+
+    public ScopedCustomization withDetachmentOptions(final int detachmentOptions) {
+        final var originalOptions = pm.getFetchPlan().getDetachmentOptions();
+        cleanUpItems.add(() -> pm.getFetchPlan().setDetachmentOptions(originalOptions));
+        pm.getFetchPlan().setDetachmentOptions(detachmentOptions);
+        return this;
+    }
+
+    public ScopedCustomization withFetchGroup(final String fetchGroup) {
+        final var originalFetchGroups = pm.getFetchPlan().getGroups();
+        cleanUpItems.add(() -> pm.getFetchPlan().setGroups(originalFetchGroups));
+        pm.getFetchPlan().setGroups(fetchGroup);
+        return this;
+    }
+
+    public ScopedCustomization withProperty(final String name, final String value) {
+        final Object originalValue = pm.getExecutionContext().getProperty(name);
+        cleanUpItems.add(() -> pm.setProperty(name, originalValue));
+        pm.setProperty(name, value);
+        return this;
+    }
+
+    @Override
+    public void close() {
+        cleanUpItems.forEach(Runnable::run);
+    }
+
+}

--- a/alpine-infra/src/main/java/alpine/persistence/Transaction.java
+++ b/alpine-infra/src/main/java/alpine/persistence/Transaction.java
@@ -1,0 +1,157 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.persistence;
+
+import javax.jdo.Constants;
+import javax.jdo.PersistenceManager;
+import java.util.ArrayList;
+import java.util.concurrent.Callable;
+
+public final class Transaction {
+
+    public enum Isolation {
+
+        READ_UNCOMMITTED,
+        READ_COMMITTED,
+        REPEATABLE_READ,
+        SNAPSHOT,
+        SERIALIZABLE;
+
+        private String jdoName() {
+            return switch (this) {
+                case READ_UNCOMMITTED -> Constants.TX_READ_UNCOMMITTED;
+                case READ_COMMITTED -> Constants.TX_READ_COMMITTED;
+                case REPEATABLE_READ -> Constants.TX_REPEATABLE_READ;
+                case SNAPSHOT -> Constants.TX_SNAPSHOT;
+                case SERIALIZABLE -> Constants.TX_SERIALIZABLE;
+            };
+        }
+
+        private static Isolation fromJdoName(final String jdoName) {
+            return switch (jdoName) {
+                case Constants.TX_READ_UNCOMMITTED -> READ_UNCOMMITTED;
+                case Constants.TX_READ_COMMITTED -> READ_COMMITTED;
+                case Constants.TX_REPEATABLE_READ -> REPEATABLE_READ;
+                case Constants.TX_SNAPSHOT -> SNAPSHOT;
+                case Constants.TX_SERIALIZABLE -> SERIALIZABLE;
+                default -> throw new IllegalArgumentException("Unknown isolation: %s".formatted(jdoName));
+            };
+        }
+
+    }
+
+    public enum Propagation {
+        REQUIRED,
+        REQUIRES_NEW
+    }
+
+    public static class Options {
+
+        private Isolation isolation;
+        private Propagation propagation;
+        private Boolean serializeRead;
+
+        public Options withIsolation(final Isolation isolation) {
+            this.isolation = isolation;
+            return this;
+        }
+
+        public Options withPropagation(final Propagation propagation) {
+            this.propagation = propagation;
+            return this;
+        }
+
+        public Options withSerializeRead(final boolean serializeRead) {
+            this.serializeRead = serializeRead;
+            return this;
+        }
+
+    }
+
+    private Transaction() {
+    }
+
+    public static Options defaultOptions() {
+        return new Options();
+    }
+
+    public static <T> T call(final PersistenceManager pm, final Options options, final Callable<T> callable) {
+        final javax.jdo.Transaction jdoTransaction = pm.currentTransaction();
+
+        // A PersistenceManager's currentTransaction is not reset upon commit or rollback.
+        // Changes made to a transaction object will persist until the owning PM is closed.
+        // Ensure we're doing our best to leave the transaction as we found it.
+        final var cleanups = new ArrayList<Runnable>();
+
+        final boolean isJoiningExisting = jdoTransaction.isActive();
+        if (isJoiningExisting && options.propagation == Propagation.REQUIRES_NEW) {
+            throw new IllegalStateException("Propagation is set to %s, but a transaction is already active"
+                    .formatted(Propagation.REQUIRES_NEW));
+        }
+
+        final Isolation currentIsolation = Isolation.fromJdoName(jdoTransaction.getIsolationLevel());
+        final Isolation requestedIsolation = options.isolation;
+        if (requestedIsolation != null && currentIsolation != requestedIsolation) {
+            if (isJoiningExisting) {
+                throw new IllegalStateException("""
+                        Requested isolation is %s, but transaction is already \
+                        active with isolation %s""".formatted(requestedIsolation, currentIsolation));
+            }
+
+            cleanups.add(() -> jdoTransaction.setIsolationLevel(currentIsolation.jdoName()));
+            jdoTransaction.setIsolationLevel(requestedIsolation.jdoName());
+        }
+
+        final Boolean currentSerializeRead = jdoTransaction.getSerializeRead();
+        final Boolean requestedSerializeRead = options.serializeRead;
+        if (requestedSerializeRead != null && currentSerializeRead != requestedSerializeRead) {
+            if (isJoiningExisting) {
+                throw new IllegalStateException("""
+                        Requested serializeRead=%s, but transaction is already \
+                        active with serializeRead=%s""".formatted(requestedSerializeRead, currentSerializeRead));
+            }
+
+            cleanups.add(() -> jdoTransaction.setSerializeRead(currentSerializeRead));
+            jdoTransaction.setSerializeRead(requestedSerializeRead);
+        }
+
+        try {
+            if (!isJoiningExisting) {
+                jdoTransaction.begin();
+            }
+
+            final T result = callable.call();
+
+            if (!isJoiningExisting) {
+                jdoTransaction.commit();
+            }
+
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (jdoTransaction.isActive() && !isJoiningExisting) {
+                jdoTransaction.rollback();
+            }
+
+            cleanups.forEach(Runnable::run);
+        }
+    }
+
+}

--- a/alpine-infra/src/test/java/alpine/persistence/ScopedCustomizationTest.java
+++ b/alpine-infra/src/test/java/alpine/persistence/ScopedCustomizationTest.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.persistence;
+
+import org.datanucleus.api.jdo.JDOPersistenceManager;
+import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jdo.JDOHelper;
+
+import static javax.jdo.FetchPlan.DETACH_LOAD_FIELDS;
+import static javax.jdo.FetchPlan.DETACH_UNLOAD_FIELDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.datanucleus.PropertyNames.PROPERTY_DETACH_ALL_ON_COMMIT;
+
+public class ScopedCustomizationTest {
+
+    private JDOPersistenceManagerFactory pmf;
+    private JDOPersistenceManager pm;
+
+    @Before
+    public void setUp() {
+        pmf = (JDOPersistenceManagerFactory) JDOHelper.getPersistenceManagerFactory(JdoProperties.unit(), "Alpine");
+        pm = (JDOPersistenceManager) pmf.getPersistenceManager();
+    }
+
+    @After
+    public void tearDown() {
+        if (pm != null) {
+            pm.close();
+        }
+
+        if (pmf != null) {
+            pmf.close();
+        }
+    }
+
+    @Test
+    public void testRestoreDetachmentOptions() {
+        pm.getFetchPlan().setDetachmentOptions(DETACH_LOAD_FIELDS);
+        assertThat(pm.getFetchPlan().getDetachmentOptions()).isEqualTo(DETACH_LOAD_FIELDS);
+
+        try (var ignored = new ScopedCustomization(pm).withDetachmentOptions(DETACH_UNLOAD_FIELDS)) {
+            assertThat(pm.getFetchPlan().getDetachmentOptions()).isEqualTo(DETACH_UNLOAD_FIELDS);
+        }
+
+        assertThat(pm.getFetchPlan().getDetachmentOptions()).isEqualTo(DETACH_LOAD_FIELDS);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRestoreFetchGroups() {
+        pm.getFetchPlan().setGroups("foo");
+        assertThat(pm.getFetchPlan().getGroups()).containsOnly("foo");
+
+        try (var ignored = new ScopedCustomization(pm).withFetchGroup("bar")) {
+            assertThat(pm.getFetchPlan().getGroups()).containsOnly("bar");
+        }
+
+        assertThat(pm.getFetchPlan().getGroups()).containsOnly("foo");
+    }
+
+    @Test
+    public void testRestoreProperties() {
+        pm.setProperty(PROPERTY_DETACH_ALL_ON_COMMIT, "true");
+        assertThat(pm.getExecutionContext().getProperty(PROPERTY_DETACH_ALL_ON_COMMIT)).isEqualTo("true");
+
+        try (var ignored = new ScopedCustomization(pm).withProperty(PROPERTY_DETACH_ALL_ON_COMMIT, "false")) {
+            assertThat(pm.getExecutionContext().getProperty(PROPERTY_DETACH_ALL_ON_COMMIT)).isEqualTo("false");
+        }
+
+        assertThat(pm.getExecutionContext().getProperty(PROPERTY_DETACH_ALL_ON_COMMIT)).isEqualTo("true");
+    }
+
+}

--- a/alpine-infra/src/test/java/alpine/persistence/TransactionTest.java
+++ b/alpine-infra/src/test/java/alpine/persistence/TransactionTest.java
@@ -1,0 +1,180 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.persistence;
+
+import alpine.model.ManagedUser;
+import alpine.model.Team;
+import alpine.persistence.Transaction.Isolation;
+import alpine.persistence.Transaction.Options;
+import alpine.persistence.Transaction.Propagation;
+import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jdo.JDOHelper;
+
+import static alpine.persistence.Transaction.defaultOptions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class TransactionTest {
+
+    private JDOPersistenceManagerFactory pmf;
+    private AlpineQueryManager qm;
+
+    @Before
+    public void setUp() {
+        pmf = (JDOPersistenceManagerFactory) JDOHelper.getPersistenceManagerFactory(JdoProperties.unit(), "Alpine");
+        qm = new AlpineQueryManager(pmf.getPersistenceManager());
+    }
+
+    @After
+    public void tearDown() {
+        if (qm != null) {
+            qm.close();
+        }
+
+        if (pmf != null) {
+            pmf.close();
+        }
+    }
+
+    @Test
+    public void testRetainValues() {
+        final Team team = qm.callInTransaction(() -> qm.createTeam("foo", true));
+        qm.close(); // Close PM to prevent lazy loading of values when getters are called.
+
+        // Ensure the values assigned during the transaction are present.
+        assertThat(team.getName()).isEqualTo("foo");
+        assertThat(team.getApiKeys()).satisfiesExactly(apiKey -> assertThat(apiKey.getKey()).isNotNull());
+    }
+
+    @Test
+    public void testTransactionRollback() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> qm.runInTransaction(() -> {
+                    final ManagedUser user = qm.createManagedUser("username", "passwordHash");
+                    final Team team = qm.createTeam("foo", true);
+                    final boolean added = qm.addUserToTeam(user, team);
+                    assertThat(added).isTrue();
+
+                    throw new IllegalStateException();
+                }))
+                .withCauseInstanceOf(IllegalStateException.class);
+
+        // Changes made in the transaction must have been rolled back.
+        assertThat(qm.getManagedUser("username")).isNull();
+        assertThat(qm.getTeam("foo")).isNull();
+    }
+
+    @Test
+    public void testNestedTransactionRollback() {
+        qm.runInTransaction(() -> {
+            final ManagedUser userA = qm.createManagedUser("usernameA", "passwordHash");
+            final ManagedUser userB = qm.createManagedUser("usernameB", "passwordHash");
+            final Team team = qm.createTeam("foo", true);
+
+            final boolean addedUserA = qm.addUserToTeam(userA, team);
+            assertThat(addedUserA).isTrue();
+
+            // Run the addition of userB to the team in a nested transaction.
+            // The transaction should join the currently active one.
+            // Throw an exception at the end. The exception must not cause
+            // the transaction to be rolled back.
+            assertThatExceptionOfType(RuntimeException.class)
+                    .isThrownBy(() -> qm.runInTransaction(() -> {
+                        final boolean addedUserB = qm.addUserToTeam(userB, team);
+                        assertThat(addedUserB).isTrue();
+
+                        throw new IllegalStateException();
+                    }));
+        });
+
+        final ManagedUser userA = qm.getManagedUser("usernameA");
+        assertThat(userA).isNotNull();
+        assertThat(userA.getTeams()).hasSize(1);
+
+        final ManagedUser userB = qm.getManagedUser("usernameB");
+        assertThat(userB).isNotNull();
+        assertThat(userB.getTeams()).hasSize(1);
+    }
+
+    @Test
+    public void testNestedTransactionWithRequiresNewPropagation() {
+        qm.runInTransaction(() ->
+                assertThatExceptionOfType(IllegalStateException.class)
+                        .isThrownBy(() -> {
+                            final Options trxOptions = defaultOptions().withPropagation(Propagation.REQUIRES_NEW);
+                            qm.runInTransaction(trxOptions, () -> {
+                            });
+                        })
+                        .withMessage("Propagation is set to REQUIRES_NEW, but a transaction is already active")
+        );
+    }
+
+    @Test
+    public void testNestedTransactionWithIsolationMismatch() {
+        qm.runInTransaction(() ->
+                assertThatExceptionOfType(IllegalStateException.class)
+                        .isThrownBy(() -> {
+                            final Options trxOptions = defaultOptions().withIsolation(Isolation.SERIALIZABLE);
+                            qm.runInTransaction(trxOptions, () -> {
+                            });
+                        })
+                        .withMessage("""
+                                Requested isolation is SERIALIZABLE, but transaction is already \
+                                active with isolation READ_COMMITTED""")
+        );
+    }
+
+    @Test
+    public void testNestedTransactionWithSerializeReadMismatch() {
+        qm.runInTransaction(() ->
+                assertThatExceptionOfType(IllegalStateException.class)
+                        .isThrownBy(() -> {
+                            final Options trxOptions = defaultOptions().withSerializeRead(true);
+                            qm.runInTransaction(trxOptions, () -> {
+                            });
+                        })
+                        .withMessage("""
+                                Requested serializeRead=true, but transaction is already \
+                                active with serializeRead=false""")
+        );
+    }
+
+    @Test
+    public void testIsolationRestore() {
+        final Options trxOptions = defaultOptions().withIsolation(Isolation.SERIALIZABLE);
+        qm.runInTransaction(trxOptions, () -> {
+        });
+
+        assertThat(qm.getPersistenceManager().currentTransaction().getIsolationLevel()).isEqualTo("read-committed");
+    }
+
+    @Test
+    public void testSerializableReadRestore() {
+        final Options trxOptions = defaultOptions().withSerializeRead(true);
+        qm.runInTransaction(trxOptions, () -> {
+        });
+
+        assertThat(qm.getPersistenceManager().currentTransaction().getSerializeRead()).isFalse();
+    }
+
+}

--- a/alpine-server/src/main/java/alpine/server/persistence/PersistenceManagerFactory.java
+++ b/alpine-server/src/main/java/alpine/server/persistence/PersistenceManagerFactory.java
@@ -76,6 +76,7 @@ public class PersistenceManagerFactory implements IPersistenceManagerFactory, Se
 
         // Apply settings that are required by Alpine and shouldn't be customized.
         dnProps.put(PropertyNames.PROPERTY_QUERY_JDOQL_ALLOWALL, "true");
+        dnProps.put(PropertyNames.PROPERTY_RETAIN_VALUES, "true");
 
         if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.METRICS_ENABLED)) {
             dnProps.put(PropertyNames.PROPERTY_ENABLE_STATISTICS, "true");


### PR DESCRIPTION
The way transactions were previously handled made it impossible to compose multiple transactional operations into larger tasks. `PersistenceManager#currentTransaction()#begin()` fails when the transaction is already active. This in turn opens the door to data inconsistencies, when parts of a task are committed but later operations fail, with no way to roll back to the original state before the task was started.

It also encouraged commits in high frequencies, which can take a toll on the database's write-ahead-log for high volume processing use-cases.

There was no handling of rollbacks, such that a failed commit could have "poisoned" an entire `PersistenceManager`, as no further persistence operations can be performed until after a rollback was executed.

This change introduces the `Transaction` class, which coordinates transaction begin, commit, and rollback. It is also capable of handling nested transactions, by joining an existing active one if required. This aspect can be controlled via propagation settings.

It also removes the need to reload objects from the database after each commit. This behavior has historically added quite a big overhead, and apparently was needed because DataNucleus transitions objects into "hollow" state (all fields except the primary key are unloaded). The unloading of fields is now disabled globally by setting the `DataNucleus.RetainValues` property to `true`.

The `ScopedCustomization` class was added to allow for scoped changes to a `PersistenceManager`, without impacting later operations on it. Usually things like adding fetch groups via `pm.getFetchPlan().addGroup("foo")` are intended to only affect one or a handful of queries, but in reality it affects all queries for the lifetime of the `PersistenceManager`. This has historically led to over-fetching. Now, it's easier to scope such things more tightly.

Further, this PR makes an effort to ensure that all `Query` objects are closed once consumed. Not closing query objects unnecessary leaks resources in cases where the owning `PersistenceManager` is **not** short-lived.

References:

* https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#lifecycle
* https://www.datanucleus.org/products/accessplatform_6_0/jdo/query.html#_closing_a_query
* https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#transaction_local
* https://github.com/search?q=repo%3AGoogleCloudPlatform%2Fdatanucleus-appengine%20retainvalues&type=code