### PR TITLE
Fix `ALPINE_DATABASE_PASSWORD_FILE` not being considered

### DIFF
--- a/alpine-server/src/main/java/alpine/server/persistence/PersistenceManagerFactory.java
+++ b/alpine-server/src/main/java/alpine/server/persistence/PersistenceManagerFactory.java
@@ -356,7 +356,7 @@ public class PersistenceManagerFactory implements IPersistenceManagerFactory, Se
         hikariConfig.setJdbcUrl(Config.getInstance().getProperty(Config.AlpineKey.DATABASE_URL));
         hikariConfig.setDriverClassName(Config.getInstance().getProperty(Config.AlpineKey.DATABASE_DRIVER));
         hikariConfig.setUsername(Config.getInstance().getProperty(Config.AlpineKey.DATABASE_USERNAME));
-        hikariConfig.setPassword(Config.getInstance().getProperty(Config.AlpineKey.DATABASE_PASSWORD));
+        hikariConfig.setPassword(Config.getInstance().getPropertyOrFile(Config.AlpineKey.DATABASE_PASSWORD));
 
         if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.METRICS_ENABLED)) {
             hikariConfig.setMetricRegistry(Metrics.getRegistry());


### PR DESCRIPTION
As reported via https://github.com/DependencyTrack/dependency-track/discussions/1987?notification_referrer_id=NT_kwDOAFbe1bI0NTA0OTczODEyOjU2OTMxNDE&notifications_query=repo%3ADependencyTrack%2Fdependency-track#discussioncomment-9276378

This appears to be a regression introduced via #439.