### PR TITLE
Make `About` extensible and add extension for database info

### DIFF
--- a/alpine-common/src/main/java/alpine/common/AboutProvider.java
+++ b/alpine-common/src/main/java/alpine/common/AboutProvider.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.common;
+
+import java.util.Map;
+
+/**
+ * @since 2.2.6
+ */
+public interface AboutProvider {
+
+    /**
+     * @return The name of the component this provider collects "about" information for
+     */
+    String name();
+
+    /**
+     * @return Information about the described component
+     */
+    Map<String, Object> collect();
+
+}

--- a/alpine-model/src/test/java/alpine/model/AboutTest.java
+++ b/alpine-model/src/test/java/alpine/model/AboutTest.java
@@ -18,9 +18,12 @@
  */
 package alpine.model;
 
+import alpine.common.AboutProvider;
 import alpine.common.util.UuidUtil;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Map;
 
 public class AboutTest {
 
@@ -36,5 +39,26 @@ public class AboutTest {
         Assert.assertTrue(about.getFramework().getVersion().startsWith("2."));
         Assert.assertTrue(about.getFramework().getTimestamp().startsWith("20"));
         Assert.assertTrue(UuidUtil.isValidUUID(about.getFramework().getUuid()));
+
+        final Map<String, Object> providerData = about.getProviderData();
+        Assert.assertEquals(1, providerData.size());
+        Assert.assertNotNull(providerData.get("test"));
+        Assert.assertTrue(providerData.get("test") instanceof Map);
+        Assert.assertEquals("bar", ((Map<String, Object>) providerData.get("test")).get("foo"));
     }
+
+    public static class TestProvider implements AboutProvider {
+
+        @Override
+        public String name() {
+            return "test";
+        }
+
+        @Override
+        public Map<String, Object> collect() {
+            return Map.of("foo", "bar");
+        }
+
+    }
+
 }

--- a/alpine-model/src/test/resources/META-INF/services/alpine.common.AboutProvider
+++ b/alpine-model/src/test/resources/META-INF/services/alpine.common.AboutProvider
@@ -1,0 +1,1 @@
+alpine.model.AboutTest$TestProvider

--- a/alpine-server/src/main/java/alpine/server/persistence/DatabaseAboutProvider.java
+++ b/alpine-server/src/main/java/alpine/server/persistence/DatabaseAboutProvider.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.server.persistence;
+
+import alpine.common.AboutProvider;
+import alpine.common.logging.Logger;
+
+import javax.jdo.PersistenceManager;
+import javax.jdo.datastore.JDOConnection;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static alpine.server.persistence.PersistenceManagerFactory.createPersistenceManager;
+
+/**
+ * An {@link AboutProvider} for database information.
+ *
+ * @since 2.2.6
+ */
+public class DatabaseAboutProvider implements AboutProvider {
+
+    private static final Logger LOGGER = Logger.getLogger(DatabaseAboutProvider.class);
+
+    @Override
+    public String name() {
+        return "database";
+    }
+
+    @Override
+    public Map<String, Object> collect() {
+        final var data = new HashMap<String, Object>();
+
+        try (final PersistenceManager pm = createPersistenceManager()) {
+            final JDOConnection jdoConnection = pm.getDataStoreConnection();
+            final var nativeConnection = (Connection) jdoConnection.getNativeConnection();
+            try {
+                final DatabaseMetaData databaseMetaData = nativeConnection.getMetaData();
+                data.put("productName", databaseMetaData.getDatabaseProductName());
+                data.put("productVersion", databaseMetaData.getDatabaseProductVersion());
+            } catch (SQLException e) {
+                LOGGER.error("Failed to retrieve database metadata", e);
+            } finally {
+                jdoConnection.close();
+            }
+        }
+
+        return data;
+    }
+
+}

--- a/alpine-server/src/main/resources/META-INF/services/alpine.common.AboutProvider
+++ b/alpine-server/src/main/resources/META-INF/services/alpine.common.AboutProvider
@@ -1,0 +1,1 @@
+alpine.server.persistence.DatabaseAboutProvider


### PR DESCRIPTION
Introduces an SPI that applications can use to provide additional data to be exposed via `/api/version`.

Adds an extension for database information.

This came from a requirement in Dependency-Track, where users want insight into what database they're running on: https://github.com/DependencyTrack/dependency-track/issues/2093

Example response of `/api/version` for Dependency-Track:

```json
{
    "version": "4.12.0-SNAPSHOT",
    "timestamp": "2024-05-14T18:33:19Z",
    "framework": {
        "version": "2.2.6-SNAPSHOT",
        "timestamp": "2024-05-14T18:32:59Z",
        "name": "Alpine",
        "uuid": "d7a6b868-13a3-4bbd-909d-a7780a9a6b8f"
    },
    "application": "Dependency-Track",
    "systemUuid": "21e013b8-8a51-4314-ac38-bed8cdde21c9",
    "uuid": "d1bf53e9-3a1a-4cd5-b65d-e969b51e9840",
    "database": {
        "productVersion": "2.2.224 (2023-09-17)",
        "productName": "H2"
    }
}
```
