### PR TITLE
Fix `NoClassDefFoundError: jakarta/servlet/ServletContext` in executable WAR

### DIFF
--- a/alpine-executable-war/pom.xml
+++ b/alpine-executable-war/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,6 @@
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
                 <version>${lib.jakarta-servlet-api.version}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>


### PR DESCRIPTION
Fixes `NoClassDefFoundError: jakarta/servlet/ServletContext` in executable WAR.

The `jakarta.servlet-api` JAR was not getting shaded into `alpine-executable-war` because it's scope defaulted to `provided`.

Removed the `scope` declaration in the parent POM. We define the `scope` explicitly in the respective Alpine modules now if it differs from `compile`.

Without the servlet API being present, the embedded Jetty failed to start with a `NoClassDefFoundError`.