### PR TITLE
Fix incorrect type parameter for `executeAndCloseResultList` and make `NotSortableException` constructor public

### DIFF
--- a/alpine-infra/src/main/java/alpine/persistence/AbstractAlpineQueryManager.java
+++ b/alpine-infra/src/main/java/alpine/persistence/AbstractAlpineQueryManager.java
@@ -695,7 +695,7 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @param <T>         Type of the {@link Query}'s result
      * @return The {@link Query}'s result
      */
-    protected <T> List<T> executeAndCloseResultList(final Query<T> query, final Class<T> resultClass) {
+    protected <T> List<T> executeAndCloseResultList(final Query<?> query, final Class<T> resultClass) {
         try {
             return new ArrayList<>(query.executeResultList(resultClass));
         } finally {

--- a/alpine-infra/src/main/java/alpine/persistence/NotSortableException.java
+++ b/alpine-infra/src/main/java/alpine/persistence/NotSortableException.java
@@ -24,21 +24,24 @@ public class NotSortableException extends IllegalArgumentException {
     private final String fieldName;
     private final String reason;
 
-    NotSortableException(final String resourceName, final String fieldName, final String reason) {
+    public NotSortableException(final String resourceName, final String fieldName, final String reason) {
         super("Can not sort by %s#%s: %s".formatted(resourceName, fieldName, reason));
         this.resourceName = resourceName;
         this.fieldName = fieldName;
         this.reason = reason;
     }
 
+    @SuppressWarnings("unused")
     public String getResourceName() {
         return resourceName;
     }
 
+    @SuppressWarnings("unused")
     public String getFieldName() {
         return fieldName;
     }
 
+    @SuppressWarnings("unused")
     public String getReason() {
         return reason;
     }

--- a/alpine-infra/src/main/java/alpine/persistence/Transaction.java
+++ b/alpine-infra/src/main/java/alpine/persistence/Transaction.java
@@ -144,6 +144,12 @@ public final class Transaction {
 
             return result;
         } catch (Exception e) {
+            if (e instanceof final RuntimeException re) {
+                // Avoid unnecessary wrapping if we're
+                // already dealing with a RuntimeException.
+                throw re;
+            }
+
             throw new RuntimeException(e);
         } finally {
             if (jdoTransaction.isActive() && !isJoiningExisting) {

--- a/alpine-infra/src/test/java/alpine/persistence/TransactionTest.java
+++ b/alpine-infra/src/test/java/alpine/persistence/TransactionTest.java
@@ -68,7 +68,7 @@ public class TransactionTest {
 
     @Test
     public void testTransactionRollback() {
-        assertThatExceptionOfType(RuntimeException.class)
+        assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> qm.runInTransaction(() -> {
                     final ManagedUser user = qm.createManagedUser("username", "passwordHash");
                     final Team team = qm.createTeam("foo", true);
@@ -76,8 +76,7 @@ public class TransactionTest {
                     assertThat(added).isTrue();
 
                     throw new IllegalStateException();
-                }))
-                .withCauseInstanceOf(IllegalStateException.class);
+                }));
 
         // Changes made in the transaction must have been rolled back.
         assertThat(qm.getManagedUser("username")).isNull();
@@ -98,7 +97,7 @@ public class TransactionTest {
             // The transaction should join the currently active one.
             // Throw an exception at the end. The exception must not cause
             // the transaction to be rolled back.
-            assertThatExceptionOfType(RuntimeException.class)
+            assertThatExceptionOfType(IllegalStateException.class)
                     .isThrownBy(() -> qm.runInTransaction(() -> {
                         final boolean addedUserB = qm.addUserToTeam(userB, team);
                         assertThat(addedUserB).isTrue();


### PR DESCRIPTION
* Fixes incorrect type parameter for `executeAndCloseResultList`
    * The result class is not necessarily equal to the candidate class of the query. Hence, using a wildcard `?` for the `Query` parameter is more fitting.
* Makes `NotSortableException` constructor public
    * So it can be used by custom query code of Alpine applications as well.
* Avoid unnecessary exception wrapping in `callInTransaction`.
* Ensure transaction cleanups are always execute.
