### PR TITLE
Raise baseline Java version to 21

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,11 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4.1.7
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: "17"
+        java-version: "21"
     - name: Install tools
       run: |
         sudo apt-get install jq

--- a/alpine-common/src/main/java/alpine/common/util/ProxyUtil.java
+++ b/alpine-common/src/main/java/alpine/common/util/ProxyUtil.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -166,7 +166,7 @@ public final class ProxyUtil {
             return null;
         }
 
-        final var proxyUrl = new URL(proxy);
+        final var proxyUrl = URI.create(proxy).toURL();
         final var proxyCfg = new ProxyConfig();
         proxyCfg.setHost(proxyUrl.getHost());
         proxyCfg.setPort(proxyUrl.getPort());

--- a/alpine-common/src/main/java/alpine/common/util/UrlUtil.java
+++ b/alpine-common/src/main/java/alpine/common/util/UrlUtil.java
@@ -21,6 +21,7 @@ package alpine.common.util;
 import org.apache.commons.lang3.StringUtils;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 
 public class UrlUtil {
@@ -54,6 +55,6 @@ public class UrlUtil {
      * @throws MalformedURLException when a URL is invalid
      */
     public static URL normalize(URL url) throws MalformedURLException {
-        return new URL(normalize(url.toExternalForm()));
+        return URI.create(normalize(url.toExternalForm())).toURL();
     }
 }

--- a/alpine-common/src/test/java/alpine/common/util/ProxyConfigTest.java
+++ b/alpine-common/src/test/java/alpine/common/util/ProxyConfigTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
 import java.util.Set;
 
 public class ProxyConfigTest {
@@ -31,18 +31,18 @@ public class ProxyConfigTest {
     public void shouldProxyWithoutHostTest() throws MalformedURLException {
         final var proxyCfg = new ProxyConfig();
         Assertions.assertFalse(proxyCfg.shouldProxy(null));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("ftp://example.com:21")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:443")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:8080")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.com:443")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.example.com:80")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://fooexample.com:80")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.bar.example.com:8000")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.net:80")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.example.net:80")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://example.org:443")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8080")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8000")));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("ftp://example.com:21").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://example.com:443").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://example.com:8080").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://www.example.com:443").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://foo.example.com:80").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://fooexample.com:80").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://foo.bar.example.com:8000").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://www.example.net:80").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://foo.example.net:80").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://example.org:443").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://127.0.0.1:8080").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://127.0.0.1:8000").toURL()));
     }
 
     @Test
@@ -50,18 +50,18 @@ public class ProxyConfigTest {
         final var proxyCfg = new ProxyConfig();
         proxyCfg.setHost("proxy.example.com");
         Assertions.assertFalse(proxyCfg.shouldProxy(null));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("ftp://example.com:21")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://example.com:443")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://example.com:8080")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://www.example.com:443")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://foo.example.com:80")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://fooexample.com:80")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://foo.bar.example.com:8000")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://www.example.net:80")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://foo.example.net:80")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://example.org:443")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8080")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8000")));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("ftp://example.com:21").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://example.com:443").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://example.com:8080").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://www.example.com:443").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://foo.example.com:80").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://fooexample.com:80").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://foo.bar.example.com:8000").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://www.example.net:80").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://foo.example.net:80").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://example.org:443").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://127.0.0.1:8080").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://127.0.0.1:8000").toURL()));
     }
 
     @Test
@@ -70,18 +70,18 @@ public class ProxyConfigTest {
         proxyCfg.setHost("proxy.example.com");
         proxyCfg.setNoProxy(Set.of("localhost:443", "127.0.0.1:8080", "example.com", "www.example.net"));
         Assertions.assertFalse(proxyCfg.shouldProxy(null));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("ftp://example.com:21")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:443")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:8080")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.com:443")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.example.com:80")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://fooexample.com:80")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.bar.example.com:8000")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.net:80")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://foo.example.net:80")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://example.org:443")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8080")));
-        Assertions.assertTrue(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8000")));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("ftp://example.com:21").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://example.com:443").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://example.com:8080").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://www.example.com:443").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://foo.example.com:80").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://fooexample.com:80").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://foo.bar.example.com:8000").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://www.example.net:80").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://foo.example.net:80").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://example.org:443").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://127.0.0.1:8080").toURL()));
+        Assertions.assertTrue(proxyCfg.shouldProxy(URI.create("http://127.0.0.1:8000").toURL()));
     }
 
     @Test
@@ -90,18 +90,18 @@ public class ProxyConfigTest {
         proxyCfg.setHost("proxy.example.com");
         proxyCfg.setNoProxy(Set.of("*"));
         Assertions.assertFalse(proxyCfg.shouldProxy(null));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("ftp://example.com:21")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:443")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://example.com:8080")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.com:443")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.example.com:80")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://fooexample.com:80")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.bar.example.com:8000")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://www.example.net:80")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://foo.example.net:80")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://example.org:443")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8080")));
-        Assertions.assertFalse(proxyCfg.shouldProxy(new URL("http://127.0.0.1:8000")));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("ftp://example.com:21").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://example.com:443").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://example.com:8080").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://www.example.com:443").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://foo.example.com:80").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://fooexample.com:80").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://foo.bar.example.com:8000").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://www.example.net:80").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://foo.example.net:80").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://example.org:443").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://127.0.0.1:8080").toURL()));
+        Assertions.assertFalse(proxyCfg.shouldProxy(URI.create("http://127.0.0.1:8000").toURL()));
     }
 
 }

--- a/alpine-common/src/test/java/alpine/common/util/UrlUtilTest.java
+++ b/alpine-common/src/test/java/alpine/common/util/UrlUtilTest.java
@@ -21,7 +21,7 @@ package alpine.common.util;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.net.URL;
+import java.net.URI;
 
 public class UrlUtilTest {
 
@@ -34,8 +34,8 @@ public class UrlUtilTest {
 
     @Test
     public void normalizationURLTest() throws Exception {
-        Assertions.assertEquals("http://www.example.com", new URL(UrlUtil.normalize("http://www.example.com")).toExternalForm());
-        Assertions.assertEquals("http://www.example.com", new URL(UrlUtil.normalize("http://www.example.com/")).toExternalForm());
-        Assertions.assertEquals("http://www.example.com", new URL(UrlUtil.normalize("http://www.example.com//////")).toExternalForm());
+        Assertions.assertEquals("http://www.example.com", URI.create(UrlUtil.normalize("http://www.example.com")).toURL().toExternalForm());
+        Assertions.assertEquals("http://www.example.com", URI.create(UrlUtil.normalize("http://www.example.com/")).toURL().toExternalForm());
+        Assertions.assertEquals("http://www.example.com", URI.create(UrlUtil.normalize("http://www.example.com//////")).toURL().toExternalForm());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
     <properties>
         <!-- Maven Build Properties -->
         <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <timestamp>${maven.build.timestamp}</timestamp>

--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-export JAVA_HOME=`/usr/libexec/java_home -v 17`
+export JAVA_HOME=`/usr/libexec/java_home -v 21`
 export PATH=JAVA_HOME/bin:$PATH
 
 read -p "Really deploy to Maven Central repository (Y/N)? "


### PR DESCRIPTION
Raises the baseline Java version to 21.

This will allow us to make use of new features introduced in Java 21 going forward.

@stevespringett Since we're already in the process of bumping Alpine's major version, I figured it is a good opportunity to perform this (breaking) change.