### PR TITLE
fix: default jwt ttl

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -182,7 +182,7 @@ public class Config {
         CORS_MAX_AGE                           ("alpine.cors.max.age",               3600),
         WATCHDOG_LOGGING_INTERVAL              ("alpine.watchdog.logging.interval",  0),
         API_KEY_PREFIX                         ("alpine.api.key.prefix",             "alpine_"),
-        AUTH_JWT_TTL_SECONDS                   ("alpine.auth.jwt.ttl.seconds",       7 * 24 * 60);
+        AUTH_JWT_TTL_SECONDS                   ("alpine.auth.jwt.ttl.seconds",       7 * 24 * 60 * 60);
 
 
         private String propertyName;


### PR DESCRIPTION
Fix an error in https://github.com/stevespringett/Alpine/pull/539

Default value `7 * 24 * 60` seconds is not 7 days.