### PR TITLE
Allow reuse of transactional database connection pool

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -114,6 +114,7 @@ public class Config {
         DATABASE_PASSWORD_FILE                 ("alpine.database.password.file",     null),
         DATABASE_MIGRATION_ENABLED             ("alpine.database.migration.enabled", true),
         DATABASE_POOL_ENABLED                  ("alpine.database.pool.enabled",      true),
+        DATABASE_POOL_TX_ONLY                  ("alpine.database.pool.tx.only",      false),
         @Deprecated
         DATABASE_POOL_MAX_SIZE                 ("alpine.database.pool.max.size",     20),
         DATABASE_POOL_TX_MAX_SIZE              ("alpine.database.pool.tx.max.size", null),        // null for backward compatibility

--- a/example/src/main/resources/application.properties
+++ b/example/src/main/resources/application.properties
@@ -97,6 +97,15 @@ alpine.database.migration.enabled=true
 alpine.database.pool.enabled=true
 
 # Optional
+# Specifies if only the transactional connection pool shall be created,
+# and re-used for non-transactional operations. This can make sense
+# for applications that handle schema migrations outside the ORM,
+# and do not use value generation strategies that require database
+# connections. The overhead of maintaining two connection pools can
+# be avoided in this case.
+alpine.database.pool.tx.only=false
+
+# Optional
 # This property controls the maximum size that the pool is allowed to reach,
 # including both idle and in-use connections.
 # The property can be set globally for both transactional and non-transactional


### PR DESCRIPTION
Maintaining two separate pools complicates operations of applications, as identifying appropriate pool sizes gets more difficult, and pool sizes tend to be configured too large, leading to too many idle connections.

Applications that do not require two separate pools can now opt out of creation of a dedicated pool for non-transactional operations.

https://groups.io/g/datanucleus/topic/best_practices_for_connection/95191894 https://groups.io/g/datanucleus/topic/side_effects_of_setting/108286305