### PR TITLE
Apply DataNucleus pass-through properties in unit test configuration

### DIFF
--- a/alpine-infra/src/main/java/alpine/persistence/JdoProperties.java
+++ b/alpine-infra/src/main/java/alpine/persistence/JdoProperties.java
@@ -77,6 +77,7 @@ public final class JdoProperties {
         properties.put(PropertyNames.PROPERTY_SCHEMA_GENERATE_DATABASE_MODE, "create");
         properties.put(PropertyNames.PROPERTY_QUERY_JDOQL_ALLOWALL, "true");
         properties.put(PropertyNames.PROPERTY_RETAIN_VALUES, "true");
+        properties.putAll(Config.getInstance().getPassThroughProperties("datanucleus"));
         return properties;
     }
 }


### PR DESCRIPTION
Any properties modified via pass-through properties should reflect in unit tests.