### PR TITLE
Allow for customization of the Jetty WebAppContext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <plugin.cyclonedx.outputReactorProjects>true</plugin.cyclonedx.outputReactorProjects>
 
         <!-- Dependency Versions -->
-        <lib.alpine.executable.war.version>3.0.2-SNAPSHOT</lib.alpine.executable.war.version>
+        <lib.alpine.executable.war.version>3.1.0-SNAPSHOT</lib.alpine.executable.war.version>
         <lib.angus-mail.version>2.0.3</lib.angus-mail.version>
         <lib.bcrypt.version>0.4</lib.bcrypt.version>
         <lib.caffeine.version>3.1.8</lib.caffeine.version>


### PR DESCRIPTION
Standalone Jetty installations provide a means to configure the context via XML files: https://jetty.org/docs/jetty/12/operations-guide/xml/index.html

The mechanism doesn't work for embedded use - XML files need to be discovered and loaded explicitly. For our purposes, applications can place a `jetty-context.xml` file in their `WEB-INF` directory in order for Alpine to discover them.

Since Alpine applications do not directly depend on `alpine-executable-war`, and thus do usually not have access to Jetty classes, the Jetty-native XML configuration was preferred over programmatic customization.

Example `jetty-context.xml` that disabled classpath scanning:

```xml
<?xml version="1.0"?>
<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
<Configure class="org.eclipse.jetty.ee10.webapp.WebAppContext">
    <Call name="setAttribute">
        <Arg>org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern</Arg>
        <Arg>^$</Arg>
    </Call>
    <Call name="setAttribute">
        <Arg>org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern</Arg>
        <Arg>^$</Arg>
    </Call>
</Configure>
```