### PR TITLE
feat: Adds permissions to API Keys

### DIFF
--- a/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
+++ b/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
@@ -798,18 +798,11 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
      * @since 1.1.1
      */
     public boolean hasPermission(final ApiKey apiKey, String permissionName) {
-        if (apiKey.getTeams() == null) {
-            return false;
-        }
-        for (final Team team: apiKey.getTeams()) {
-            final List<Permission> teamPermissions = getObjectById(Team.class, team.getId()).getPermissions();
-            for (final Permission permission: teamPermissions) {
-                if (permission.getName().equals(permissionName)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        final Query<Permission> query = pm.newQuery(Permission.class, "name == :permissionName && apiKey.contains(apiKey) && apiKey.id == :apiKeyId");
+        query.declareVariables("alpine.model.ApiKey apiKey");
+        query.setParameters(permissionName, apiKey.getId());
+        query.setResult("count(id)");
+        return executeAndCloseResultUnique(query, Long.class) > 0;
     }
 
     /**

--- a/alpine-model/src/main/java/alpine/model/ApiKey.java
+++ b/alpine-model/src/main/java/alpine/model/ApiKey.java
@@ -86,6 +86,11 @@ public class ApiKey implements Serializable, Principal {
     @JsonIgnore
     private List<Team> teams;
 
+    @Persistent(table = "APIKEYS_PERMISSIONS", defaultFetchGroup = "true")
+    @Join(column = "APIKEY_ID")
+    @Element(column = "PERMISSION_ID")
+    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
+    private List<Permission> permissions;
     public long getId() {
         return id;
     }
@@ -166,5 +171,12 @@ public class ApiKey implements Serializable, Principal {
         this.teams = teams;
     }
 
-}
+    public List<Permission> getPermissions() {
+        return permissions;
+    }
 
+    public void setPermissions(List<Permission> permissions) {
+        this.permissions = permissions;
+    }
+
+}

--- a/alpine-model/src/main/java/alpine/model/Permission.java
+++ b/alpine-model/src/main/java/alpine/model/Permission.java
@@ -85,6 +85,11 @@ public class Permission implements Serializable {
     @JsonIgnore
     private List<ManagedUser> managedUsers;
 
+    @Persistent(mappedBy = "permissions")
+    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "username ASC"))
+    @JsonIgnore
+    private List<ApiKey> apiKeys;
+
     public long getId() {
         return id;
     }
@@ -140,5 +145,12 @@ public class Permission implements Serializable {
     public void setManagedUsers(List<ManagedUser> managedUsers) {
         this.managedUsers = managedUsers;
     }
-}
 
+    public List<ApiKey> getApiKeys() {
+        return apiKeys;
+    }
+
+    public void setApiKeys(List<ApiKey> apiKeys) {
+        this.apiKeys = apiKeys;
+    }
+}

--- a/alpine-model/src/test/java/alpine/model/ApiKeyTest.java
+++ b/alpine-model/src/test/java/alpine/model/ApiKeyTest.java
@@ -85,4 +85,14 @@ public class ApiKeyTest {
         Assertions.assertEquals(teams, key.getTeams());
         Assertions.assertEquals(1, key.getTeams().size());
     }
+
+    @Test
+    public void permissionsTest() {
+        List<Permission> permissions = new ArrayList<>();
+        permissions.add(new Permission());
+        ApiKey user = new ApiKey();
+        user.setPermissions(permissions);
+        Assertions.assertEquals(permissions, user.getPermissions());
+        Assertions.assertEquals(1, user.getPermissions().size());
+    }
 }


### PR DESCRIPTION
This PR addresses [#532](https://github.com/stevespringett/Alpine/issues/532#issuecomment-2378988533) by implementing Permissions for API Keys.

Adds permissions to the API Key in a similar way as it is added to teams and users and removed checking permissions for keys over team permissions.