### PR TITLE
Fix use of `getPropertyOrFile` for database password

### DIFF
--- a/alpine-server/src/main/java/alpine/server/upgrade/UpgradeMetaProcessor.java
+++ b/alpine-server/src/main/java/alpine/server/upgrade/UpgradeMetaProcessor.java
@@ -181,7 +181,7 @@ public class UpgradeMetaProcessor implements Closeable {
         final String driver = Config.getInstance().getProperty(Config.AlpineKey.DATABASE_DRIVER);
         final String dbUrl = Config.getInstance().getProperty(Config.AlpineKey.DATABASE_URL);
         final String user = Config.getInstance().getProperty(Config.AlpineKey.DATABASE_USERNAME);
-        final String password = Config.getInstance().getProperty(Config.AlpineKey.DATABASE_PASSWORD);
+        final String password = Config.getInstance().getPropertyOrFile(Config.AlpineKey.DATABASE_PASSWORD);
         try {
             Class.forName(driver);
             return DriverManager.getConnection(dbUrl, user, password);


### PR DESCRIPTION
Related to DependencyTrack/dependency-track#1987

This is an addition to #557, DependencyTrack still does not start with `ALPINE_DATABASE_PASSWORD_FILE`.

Unfortunately, I do not have a functional Java environment, so I could not test this patch.