### PR TITLE
Fix erroneous attempts of OIDC default team assignment

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -30,12 +30,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
+
+import static java.util.function.Predicate.not;
 
 /**
  * The Config class is responsible for reading the application.properties file.
@@ -521,7 +524,10 @@ public class Config {
         if (property == null) {
             return Collections.emptyList();
         } else {
-            return List.of(property.split(","));
+            return Arrays.stream(property.split(","))
+                    .map(String::trim)
+                    .filter(not(String::isEmpty))
+                    .toList();
         }
     }
 

--- a/alpine-server/src/main/java/alpine/server/auth/OidcAuthenticationService.java
+++ b/alpine-server/src/main/java/alpine/server/auth/OidcAuthenticationService.java
@@ -28,6 +28,7 @@ import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 
 import jakarta.annotation.Nonnull;
 import java.security.Principal;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -235,10 +236,15 @@ public class OidcAuthenticationService implements AuthenticationService {
         if (config.getPropertyAsBoolean(Config.AlpineKey.OIDC_TEAM_SYNCHRONIZATION)) {
             LOGGER.debug("Synchronizing teams for user " + user.getUsername());
             return qm.synchronizeTeamMembership(user, profile.getGroups());
-        } else {
-            // Only apply default teams during auto-provisioning, not on later updates:
-            return qm.addUserToTeams(user, config.getPropertyAsList(Config.AlpineKey.OIDC_TEAMS_DEFAULT));
         }
+
+        final List<String> defaultTeams = config.getPropertyAsList(Config.AlpineKey.OIDC_TEAMS_DEFAULT);
+        if (!defaultTeams.isEmpty()) {
+            LOGGER.debug("Assigning default teams %s to user %s".formatted(defaultTeams, user.getUsername()));
+            return qm.addUserToTeams(user, defaultTeams);
+        }
+
+        return user;
     }
 
 }


### PR DESCRIPTION
Assigning of users to default teams should only happen when the corresponding property is populated. Also ensure that whitespace properties are filtered out.

Relates to https://github.com/DependencyTrack/dependency-track/issues/4371#issuecomment-2486109369