### PR TITLE
Fix `SendMail` performing hostname verification despite `trustCert` being enabled

### DIFF
--- a/alpine-server/src/main/java/alpine/server/mail/SendMail.java
+++ b/alpine-server/src/main/java/alpine/server/mail/SendMail.java
@@ -196,6 +196,7 @@ public class SendMail {
                 throw new SendMailException("An error occurred while configuring trust managers", e);
             }
             props.put("mail.smtp.ssl.socketFactory", sf);
+            props.put("mail.smtp.ssl.checkserveridentity", false);
         } else if (useStartTLS) {
             props.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
         }


### PR DESCRIPTION
Fixes `SendMail` performing hostname verification despite `trustCert` being enabled.

In older implementations of the Java Mail API, `mail.smtp.ssl.checkserveridentity` defaulted to `false`. With Eclipse Angus, it was changed to `true`.

https://github.com/eclipse-ee4j/angus-mail/pull/14