### PR TITLE
Disable Maven transfer progress logs in CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,12 +1,17 @@
 name: Maven CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request:
+    branches:
+    - 'master'
+  workflow_dispatch: {}
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4.2.2
     - name: Set up JDK 21

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,4 +19,4 @@ jobs:
         sudo apt-get install jq
         wget -O ~/codacy-coverage-reporter-assembly.jar https://github.com/codacy/codacy-coverage-reporter/releases/download/4.0.5/codacy-coverage-reporter-4.0.5-assembly.jar
     - name: Build with Maven
-      run: mvn clean install
+      run: mvn -B --no-transfer-progress clean install

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -18,7 +18,7 @@ jobs:
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
     - name: Publish snapshot
-      run: mvn -B deploy
+      run: mvn -B --no-transfer-progress deploy
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         # This requires the connection and developerConnection elements in the scm section of the pom
         # to be set to "scm:git:https:...." thus preventing the release plugin from using SSH.
         run: |
-          mvn -B ${{ env.options }}
+          mvn -B --no-transfer-progress ${{ env.options }}
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
         if: failure() && github.event.inputs.dry_run == false
         run: |
           echo "Release failed. Rolling back..."
-          mvn -B release:rollback -Prelease
+          mvn -B --no-transfer-progress release:rollback -Prelease
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}


### PR DESCRIPTION
Download progress is not useful and just clutters the build logs.

Also fix CI workflow running twice for each PR commit.