### PR TITLE
Add property to allow disable username/password login

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -186,7 +186,8 @@ public class Config {
         CORS_MAX_AGE                           ("alpine.cors.max.age",               3600),
         WATCHDOG_LOGGING_INTERVAL              ("alpine.watchdog.logging.interval",  0),
         API_KEY_PREFIX                         ("alpine.api.key.prefix",             "alpine_"),
-        AUTH_JWT_TTL_SECONDS                   ("alpine.auth.jwt.ttl.seconds",       7 * 24 * 60 * 60);
+        AUTH_JWT_TTL_SECONDS                   ("alpine.auth.jwt.ttl.seconds",       7 * 24 * 60 * 60),
+        USERNAMEPASSWORD_ENABLED               ("alpine.usernamepassword.enabled",    true);
 
 
         private String propertyName;


### PR DESCRIPTION
Property `alpine.usernamepassword.enabled` is needed to allows disable/enable username/password Authentication in Dependency Track
Related issue Dependency Track issue: https://github.com/DependencyTrack/dependency-track/issues/4955 