### PR TITLE
Remove watchdog logging

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -184,7 +184,6 @@ public class Config {
         CORS_EXPOSE_HEADERS                    ("alpine.cors.expose.headers",        "Origin, Content-Type, Authorization, X-Requested-With, Content-Length, Accept, Origin, X-Api-Key, X-Total-Count"),
         CORS_ALLOW_CREDENTIALS                 ("alpine.cors.allow.credentials",     true),
         CORS_MAX_AGE                           ("alpine.cors.max.age",               3600),
-        WATCHDOG_LOGGING_INTERVAL              ("alpine.watchdog.logging.interval",  0),
         API_KEY_PREFIX                         ("alpine.api.key.prefix",             "alpine_"),
         AUTH_JWT_TTL_SECONDS                   ("alpine.auth.jwt.ttl.seconds",       7 * 24 * 60 * 60);
 

--- a/alpine-server/src/main/java/alpine/server/AlpineServlet.java
+++ b/alpine-server/src/main/java/alpine/server/AlpineServlet.java
@@ -22,8 +22,6 @@ import alpine.Config;
 import alpine.common.logging.Logger;
 import alpine.security.crypto.KeyManager;
 import org.glassfish.jersey.servlet.ServletContainer;
-import org.owasp.security.logging.util.IntervalLoggerController;
-import org.owasp.security.logging.util.SecurityLoggingFactory;
 import org.owasp.security.logging.util.SecurityUtil;
 
 import jakarta.servlet.ServletConfig;
@@ -61,12 +59,6 @@ public class AlpineServlet extends ServletContainer {
         // Log all Java System Properties
         SecurityUtil.logJavaSystemProperties();
 
-        // Determine if Watchdog logging is enabled and if so, start interval logging
-        final int interval = Config.getInstance().getPropertyAsInt(Config.AlpineKey.WATCHDOG_LOGGING_INTERVAL);
-        if (interval > 0) {
-            final IntervalLoggerController wd = SecurityLoggingFactory.getControllerInstance();
-            wd.start(interval * 1000); // Interval is defined in seconds
-        }
         LOGGER.info(Config.getInstance().getApplicationName() + " is ready");
     }
 

--- a/example/src/main/resources/application.properties
+++ b/example/src/main/resources/application.properties
@@ -44,11 +44,6 @@ alpine.data.directory=~/.alpine-example
 # alpine.api.key.prefix=alpine_
 
 # Required
-# Defines the interval (in seconds) to log general heath information.
-# If value equals 0, watchdog logging will be disabled.
-alpine.watchdog.logging.interval=0
-
-# Required
 # Defines the database mode of operation. Valid choices are:
 # 'server', 'embedded', and 'external'.
 # In server mode, the database will listen for connections from remote


### PR DESCRIPTION
The implementation uses busy-looping which causes excessive CPU usage for no benefit at all.

Given we already have `/health` and `/metrics` endpoints to monitor applications, watchdog logging is not necessary anymore.

This was identified as an issue via https://github.com/DependencyTrack/dependency-track/issues/5021