### PR TITLE
Adjust release process for new Maven Central publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,9 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
           # Export the gpg private key using the following command and add the contents of that file to the GitHub secret
           # gpg --armor --export-secret-keys <key_id> > gpg_key.asc
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -37,17 +37,15 @@ jobs:
         run: |
           git config --global user.email "steve@springett.us"
           git config --global user.name "Steve Springett"
-          git config --global credential.helper 'store --file ~/.git-credentials'
-          echo "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com" > ~/.git-credentials
 
       - name: Set Maven options
         id: maven_options
         run: |
           # Set the Maven options based on the 'dry_run' input
           if ${{ github.event.inputs.dry_run }}; then
-            echo "options=release:prepare -DdryRun=true -Prelease" >> $GITHUB_ENV
+            echo "options=release:prepare -DdryRun=true" >> $GITHUB_ENV
           else
-            echo "options=release:clean release:prepare release:perform -Prelease" >> $GITHUB_ENV
+            echo "options=release:clean release:prepare release:perform" >> $GITHUB_ENV
           fi
 
       - name: Run Maven command
@@ -56,8 +54,8 @@ jobs:
         run: |
           mvn -B --no-transfer-progress ${{ env.options }}
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: ${{ github.event.inputs.dry_run == false }}
@@ -68,7 +66,7 @@ jobs:
           echo "Release failed. Rolling back..."
           mvn -B --no-transfer-progress release:rollback -Prelease
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/stevespringett/Alpine.git</connection>
-        <developerConnection>scm:git:https://github.com/stevespringett/Alpine.git</developerConnection>
-        <url>https://github.com/stevespringett/Alpine.git</url>
+        <connection>${scm.connection}</connection>
+        <developerConnection>${scm.developerConnection}</developerConnection>
+        <url>${scm.url}</url>
         <tag>HEAD</tag>
     </scm>
 
@@ -75,17 +75,6 @@
         <system>GitHub-Actions</system>
         <url>https://github.com/stevespringett/Alpine/actions</url>
     </ciManagement>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <properties>
         <!-- Maven Build Properties -->
@@ -200,6 +189,11 @@
 
         <!-- Logback configuration - Used for Embedded Jetty profile -->
         <logback.configuration.file>${project.build.directory}/classes/logback.xml</logback.configuration.file>
+
+        <!-- Default SCM Properties -->
+        <scm.connection>scm:git:https://github.com/stevespringett/Alpine.git</scm.connection>
+        <scm.developerConnection>scm:git:https://github.com/stevespringett/Alpine.git</scm.developerConnection>
+        <scm.url>https://github.com/stevespringett/Alpine.git</scm.url>
     </properties>
 
     <dependencyManagement>
@@ -623,6 +617,28 @@
                     <destFile>target/jacoco.exec</destFile>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <projectVersionPolicyId>SemVerVersionPolicy</projectVersionPolicyId>
+                    <tagNameFormat>@{project.artifactId}-@{project.version}</tagNameFormat>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <autoPublish>true</autoPublish>
+                    <publishingServerId>central</publishingServerId>
+                </configuration>
+            </plugin>
         </plugins>
 
         <resources>
@@ -642,6 +658,27 @@
     </build>
 
     <profiles>
+        <profile>
+            <!--
+              When running in GitHub Actions, the SCM connection must be via HTTPS
+              so that the GITHUB_TOKEN injected by Actions can be used to authenticate.
+
+              Connection URLs target the repository for which the Actions workflow is
+              running, enabling the release process to be tested in forks.
+            -->
+            <id>github-actions</id>
+            <activation>
+                <property>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <scm.connection>scm:git:https://github.com/${env.GITHUB_REPOSITORY}.git</scm.connection>
+                <scm.developerConnection>scm:git:https://github.com/${env.GITHUB_REPOSITORY}.git</scm.developerConnection>
+                <scm.url>https://github.com/${env.GITHUB_REPOSITORY}.git</scm.url>
+            </properties>
+        </profile>
         <profile>
             <id>enhance</id>
             <build>


### PR DESCRIPTION
Adjusts the release process for new Maven Central publishing.

@stevespringett, please generate a username and token as outlined [here](https://central.sonatype.org/publish/generate-portal-token/), and configure them as secrets for GitHub Actions.

Please also enable `SNAPSHOT` publishing for the namespace as described [here](https://central.sonatype.org/publish/publish-portal-snapshots/#enabling-snapshot-releases-for-your-namespace).