### PR TITLE
Revert version to 3.3.0-SNAPSHOT

### DIFF
--- a/alpine-common/pom.xml
+++ b/alpine-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>alpine-parent</artifactId>
         <groupId>us.springett</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alpine-common</artifactId>

--- a/alpine-executable-war/pom.xml
+++ b/alpine-executable-war/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>alpine-parent</artifactId>
         <groupId>us.springett</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/alpine-infra/pom.xml
+++ b/alpine-infra/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>alpine-parent</artifactId>
         <groupId>us.springett</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alpine-infra</artifactId>

--- a/alpine-model/pom.xml
+++ b/alpine-model/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>alpine-parent</artifactId>
         <groupId>us.springett</groupId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alpine-model</artifactId>

--- a/alpine-server/pom.xml
+++ b/alpine-server/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>us.springett</groupId>
         <artifactId>alpine-parent</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>alpine-server</artifactId>
     <packaging>jar</packaging>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
 
     <name>alpine-server</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>us.springett</groupId>
     <artifactId>alpine-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
 
     <modules>
         <module>alpine-common</module>
@@ -146,7 +146,7 @@
         <plugin.cyclonedx.outputReactorProjects>true</plugin.cyclonedx.outputReactorProjects>
 
         <!-- Dependency Versions -->
-        <lib.alpine.executable.war.version>3.4.0-SNAPSHOT</lib.alpine.executable.war.version>
+        <lib.alpine.executable.war.version>3.3.0-SNAPSHOT</lib.alpine.executable.war.version>
         <lib.angus-mail.version>2.0.4</lib.angus-mail.version>
         <lib.bcrypt.version>0.4</lib.bcrypt.version>
         <lib.caffeine.version>3.2.2</lib.caffeine.version>


### PR DESCRIPTION
And add missing `name` properties to Maven modules. Central validates their presence now: https://central.sonatype.org/publish/requirements/#project-name-description-and-url