### PR TITLE
Add missing `name` properties to Maven modules

### DIFF
--- a/alpine-common/pom.xml
+++ b/alpine-common/pom.xml
@@ -26,6 +26,8 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alpine-common</artifactId>
 
+    <name>${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/alpine-executable-war/pom.xml
+++ b/alpine-executable-war/pom.xml
@@ -28,6 +28,8 @@
     <artifactId>alpine-executable-war</artifactId>
     <packaging>jar</packaging>
 
+    <name>${project.artifactId}</name>
+
     <properties>
         <maven.uuidgenerator.plugin.version>1.0.1</maven.uuidgenerator.plugin.version>
     </properties>

--- a/alpine-infra/pom.xml
+++ b/alpine-infra/pom.xml
@@ -26,6 +26,8 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alpine-infra</artifactId>
 
+    <name>${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>us.springett</groupId>

--- a/alpine-model/pom.xml
+++ b/alpine-model/pom.xml
@@ -26,6 +26,8 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alpine-model</artifactId>
 
+    <name>${project.artifactId}</name>
+
     <dependencies>
         <dependency>
             <groupId>us.springett</groupId>

--- a/alpine-server/pom.xml
+++ b/alpine-server/pom.xml
@@ -29,7 +29,7 @@
     <packaging>jar</packaging>
     <version>3.3.0-SNAPSHOT</version>
 
-    <name>alpine-server</name>
+    <name>${project.artifactId}</name>
     <description>
         An opinionated scaffolding library that jumpstarts Java projects with an API-first design,
         secure defaults, and minimal dependencies.


### PR DESCRIPTION
Central validates their presence now: https://central.sonatype.org/publish/requirements/#project-name-description-and-url