### PR TITLE
Throws IllegalStateException when id.system is not readable/writable

### DIFF
--- a/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine-common/src/main/java/alpine/Config.java
@@ -302,13 +302,16 @@ public class Config {
             try (OutputStream fos = Files.newOutputStream(systemIdFile.toPath())) {
                 fos.write(UUID.randomUUID().toString().getBytes());
             } catch (IOException e) {
-                LOGGER.error("An error occurred writing to " + systemIdFile.getAbsolutePath(), e);
+                throw new IllegalStateException("An error occurred writing to " + systemIdFile.getAbsolutePath(), e);
             }
         }
         try {
-            systemId = new String(Files.readAllBytes(systemIdFile.toPath()));
+            systemId = Files.readString(systemIdFile.toPath());
+            if (StringUtils.isBlank(systemId)) {
+                throw new IllegalStateException("System ID file exists but is empty: " + systemIdFile.getAbsolutePath());
+            }
         } catch (IOException e) {
-            LOGGER.error("Unable to read the contents of " + systemIdFile.getAbsolutePath(), e);
+            throw new IllegalStateException("Unable to read the contents of " + systemIdFile.getAbsolutePath(), e);
         }
     }
 


### PR DESCRIPTION
Throw an IllegalStateException if system.id cannot be read or written, allowing the application to decide whether to exit or continue.
See the related DependencyTrack issue: https://github.com/DependencyTrack/dependency-track/issues/5121