### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,9 +167,9 @@
         <lib.jsr305.version>3.0.2</lib.jsr305.version>
         <lib.logback.version>1.5.32</lib.logback.version>
         <lib.logstash-logback-encoder.version>8.1</lib.logstash-logback-encoder.version>
-        <lib.micrometer.version>1.16.3</lib.micrometer.version>
+        <lib.micrometer.version>1.16.4</lib.micrometer.version>
         <lib.microprofile-health-api.version>4.0.1</lib.microprofile-health-api.version>
-        <lib.nimbus-oauth2-oidc-sdk.version>11.33</lib.nimbus-oauth2-oidc-sdk.version>
+        <lib.nimbus-oauth2-oidc-sdk.version>11.34</lib.nimbus-oauth2-oidc-sdk.version>
         <lib.owasp.encoder.version>1.4.0</lib.owasp.encoder.version>
         <lib.owasp.security-logging.version>1.1.7</lib.owasp.security-logging.version>
         <lib.parsson.version>1.1.7</lib.parsson.version>


### PR DESCRIPTION
Includes minor and patch version bumps for Micrometer and Nimbus OIDC that Dependabot hasn't yet raised PRs for.